### PR TITLE
Switch how we reload the window

### DIFF
--- a/assets/js/yoast-toggle.js
+++ b/assets/js/yoast-toggle.js
@@ -11,7 +11,7 @@ var Yoast_Plugin_Toggler = {
 			},
 			function( response ) {
 				if ( response.activated_version !== undefined ) {
-					window.history.go(0);
+					window.location.reload(true);
 				}
 			}
 		);


### PR DESCRIPTION
The `window.history.go` stuff didn't work properly on Safari. This does. Please test it in Chrome.