### PR TITLE
Try a debug bar panel

### DIFF
--- a/src/Admin_Debug_Info.php
+++ b/src/Admin_Debug_Info.php
@@ -31,7 +31,7 @@ class Admin_Debug_Info implements Integration {
 	 * @return void
 	 */
 	public function add_hooks() {
-		add_action( 'wpseo_admin_footer', array( $this, 'show_debug_info' ), 90, 1 );
+		add_filter( 'debug_bar_panels', array( $this, 'add_debug_panel' ) );
 
 		add_action(
 			'admin_post_yoast_seo_debug_settings',
@@ -40,25 +40,18 @@ class Admin_Debug_Info implements Integration {
 	}
 
 	/**
-	 * Shows debug info about the current option
+	 * Makes the debug info appear in a Debug Bar panel.
 	 *
-	 * @param \Yoast_Form $form Form instance.
+	 * @param array $panels Existing debug bar panels.
 	 *
-	 * @return void
+	 * @return array Panels array.
 	 */
-	public function show_debug_info( $form ) {
-		if ( $this->option->get( 'show_options_debug' ) ) {
-			$xdebug = ( extension_loaded( 'xdebug' ) ? true : false );
-			echo '<div id="wpseo-debug-info" class="yoast-container">';
-			echo '<h2>Debug Information</h2>';
-			echo '<div>';
-			echo '<h3 class="wpseo-debug-heading">Current option: <span class="wpseo-debug">' . esc_html( $form->option_name ) . '</span></h3>';
-			echo( ( $xdebug ) ? '' : '<pre>' );
-			// @codingStandardsIgnoreLine.
-			var_dump( $form->get_option() );
-			echo( ( $xdebug ) ? '' : '</pre>' );
-			echo '</div></div>';
+	public function add_debug_panel( $panels ) {
+		if ( $this->option->get( 'show_options_debug' ) === true ) {
+			require_once 'Yoast_SEO_Admin_Bar_Debug_Panel.php';
+			$panels[] = new \Yoast_SEO_Admin_Bar_Debug_Panel();
 		}
+		return $panels;
 	}
 
 	/**

--- a/src/Yoast_SEO_Admin_Bar_Debug_Panel.php
+++ b/src/Yoast_SEO_Admin_Bar_Debug_Panel.php
@@ -34,7 +34,7 @@ class Yoast_SEO_Admin_Bar_Debug_Panel extends \Debug_Bar_Panel {
 		foreach ( WPSEO_Options::get_option_names() as $option ) {
 			echo '<h3 id="' . esc_attr( $option ) . '">Option: <span class="wpseo-debug">' . esc_html( $option ) . '</span></h3>';
 			echo '<pre>';
-			// @codingStandardsIgnoreLine.
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export,WordPress.XSS.EscapeOutput.OutputNotEscaped
 			echo var_export( get_option( $option ) );
 			echo '</pre>';
 		}

--- a/src/Yoast_SEO_Admin_Bar_Debug_Panel.php
+++ b/src/Yoast_SEO_Admin_Bar_Debug_Panel.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Admin page hander.
+ *
+ * @package Yoast\Yoast_SEO_Admin_Bar_Debug_Panel
+ *
+ * Cannot use a namespace because the DebugBar plugin uses classnames as CSS selectors and the slashes this returns
+ * for namespaced classes cause havoc everywhere.
+ */
+
+/**
+ * Class to manage registering and rendering the admin page in WordPress.
+ */
+class Yoast_SEO_Admin_Bar_Debug_Panel extends \Debug_Bar_Panel {
+	/**
+	 * Admin_Bar_Debug_Panel constructor.
+	 */
+	public function __construct() {
+		$this->set_visible( true );
+		parent::__construct( 'Yoast SEO' );
+	}
+
+	/**
+	 * Renders the debug panel.
+	 */
+	public function render() {
+		echo '<h2>Debug Information</h2>';
+		echo '<div class="clear"></div>';
+		echo '<ul>';
+		foreach ( WPSEO_Options::get_option_names() as $option ) {
+			printf( '<li><a style="text-decoration: none !important;" href="#%1$s">%2$s</a></li>', esc_attr( $option ), esc_html( $option ) );
+		}
+		echo '</ul>';
+		foreach ( WPSEO_Options::get_option_names() as $option ) {
+			echo '<h3 id="' . esc_attr( $option ) . '">Option: <span class="wpseo-debug">' . esc_html( $option ) . '</span></h3>';
+			echo '<pre>';
+			// @codingStandardsIgnoreLine.
+			echo var_export( get_option( $option ) );
+			echo '</pre>';
+		}
+	}
+}


### PR DESCRIPTION
This moves the options display for Yoast SEO from underneath the settings screens to a debug bar panel which is always visible.