### PR TITLE
Automatically commit all files from a tagged commit to the dist repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,10 +66,9 @@ script:
 
  # If the commit was tagged, create an artifact and push it to the distribution github
 deploy:
-  script: grunt artifact
   skip_cleanup: true
   provider: script
-  script: bash scripts/deploy_to_dist.sh
+  script: grunt artifact || scripts/deploy_to_dist.sh
   on:
     tags: true
     repo: Yoast/wordpress-seo

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,3 +63,14 @@ script:
 # Validate the composer.json file.
 # @link https://getcomposer.org/doc/03-cli.md#validate
 - if [[ $TRAVIS_PHP_VERSION == "5.3" || $TRAVIS_PHP_VERSION == "7.2" ]]; then composer validate --no-check-all; fi
+
+ # If the commit was tagged, create an artifact and push it to the distribution github
+deploy:
+  script: grunt artifact
+  skip_cleanup: true
+  provider: script
+  script: bash scripts/deploy_to_dist.sh
+  on:
+    tags: true
+    repo: Yoast/wordpress-seo
+    all_branches: true

--- a/scripts/deploy_to_dist.sh
+++ b/scripts/deploy_to_dist.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Repo to deploy to:
+USER="Yoast-dist"
+REPO="wordpress-seo"
+REPO_URL="git@github.com:$USER/$REPO.git"
+# Get the latest tag
+lastTag=$(git describe --abbrev=0 --tags)
+mainDir=$(pwd)
+# Create a new git repos
+cd ./artifact
+git init
+git remote add origin ${REPO_URL}
+#commit the files
+git add -A
+git commit -m "commit version tag ${lastTag} "
+#tag the commit
+git tag ${lastTag} $(git rev-parse HEAD)
+#push
+git push -u origin master --tags -f -v

--- a/scripts/deploy_to_dist.sh
+++ b/scripts/deploy_to_dist.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 # Repo to deploy to:
 USER="Yoast-dist"
-REPO="wordpress-seo"
+REPO="yoast-test-helper"
 REPO_URL="git@github.com:$USER/$REPO.git"
 # Get the latest tag
-lastTag=$(git describe --abbrev=0 --tags)
+#lastTag=$(git describe --abbrev=0 --tags)
+lastTag=$(TRAVIS_TAG)
 mainDir=$(pwd)
 # Create a new git repos
 cd ./artifact


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

*  automatically commit all files from a tagged commit to the dist repo

## Relevant technical choices:

* Using Travis to automatically commit all files from a tagged commit to the dist repo

## Test instructions

This PR can be tested by following these steps:

* Creating a tagged commit, pushing it to the GitHub remote and verifying if the files are in the distribution git 

Fixes #16 