### PR TITLE
Allow an inline script to be injected after a specified wpseo script.

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -64,11 +64,23 @@ div.wpseo_test_block button.button[type=submit]{
     margin: 20px 10px 0 0 !important;
 }
 
-div.wpseo_test_block input[type=checkbox]{
+div.wpseo_test_block input[type=checkbox] {
     margin: 5px 10px 5px 0;
 }
 
 div.wpseo_test_block input[type=number]{
     width: 80px;
     margin: 5px 0 5px 10px;
+}
+
+div.wpseo_test_block textarea {
+    margin: 10px 0;
+}
+
+div.wpseo_test_block label {
+    font-size: 1em;
+}
+
+div.wpseo_test_block label code {
+    font-size: 0.9em;
 }

--- a/src/Inline_Script.php
+++ b/src/Inline_Script.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Detects if an upgrade is ran.
+ *
+ * @package Yoast\Test_Helper
+ */
+
+namespace Yoast\Test_Helper;
+
+class Inline_Script implements Integration {
+	/**
+	 * Holds our option instance.
+	 *
+	 * @var Option
+	 */
+	private $option;
+
+	/**
+	 * Class constructor.
+	 *
+	 * @param Option $option Our option array.
+	 */
+	public function __construct( Option $option ) {
+		$this->option = $option;
+	}
+
+	/**
+	 * Registers WordPress hooks and filters.
+	 *
+	 * @return void
+	 */
+	public function add_hooks() {
+		if( $this->option->get( 'add_inline_script' ) == true ) {
+			add_action( 'admin_enqueue_scripts', array( $this, 'add_inline_script' ) );
+		}
+
+		add_action( 'admin_post_yoast_seo_test_inline_script', array( $this, 'handle_submit' ) );
+	}
+
+	/**
+	 * Add an inline script after the specified script.
+	 */
+	public function add_inline_script() {
+		wp_add_inline_script(
+			'yoast-seo-' . $this->option->get( 'inline_script_handle' ),
+			$this->option->get( 'inline_script' )
+		);
+	}
+
+	/**
+	 * Retrieves the controls.
+	 *
+	 * @return string The HTML to use to render the controls.
+	 */
+	public function get_controls() {
+		$output  = Form_Presenter::create_checkbox(
+			'add_inline_script', 'Add the specified inline script',
+			$this->option->get( 'add_inline_script' )
+		);
+
+		$value = $this->option->get( 'inline_script_handle' );
+		$output .= '<label for="inline_script_handle">Handle: </label>';
+		$output .= '<input value="' . $value . '" name="inline_script_handle" id="inline_script_handle"/><br/>';
+
+		$value = $this->option->get( 'inline_script' );
+		$output .= '<label for="inline_script">Script:</label><br/>';
+		$output .= '<textarea style="width: 100%; min-height: 300px; font-family: monospace;" name="inline_script" id="inline_script">' . stripslashes( $value ) . '</textarea><br/>';
+		return Form_Presenter::get_html( 'Inline script', 'yoast_seo_test_inline_script', $output );
+	}
+
+	/**
+	 * Handles the form submit.
+	 *
+	 * @return void
+	 */
+	public function handle_submit() {
+		if ( check_admin_referer( 'yoast_seo_test_inline_script' ) !== false ) {
+			$this->option->set( 'add_inline_script', isset( $_POST['add_inline_script'] ) );
+			$this->option->set( 'inline_script_handle', (string) $_POST['inline_script_handle'] );
+			$this->option->set( 'inline_script', stripslashes( (string) $_POST['inline_script'] ) );
+		}
+
+		wp_safe_redirect( self_admin_url( 'tools.php?page=' . apply_filters( 'yoast_version_control_admin_page', '' ) ) );
+	}
+}

--- a/src/Inline_Script.php
+++ b/src/Inline_Script.php
@@ -7,6 +7,9 @@
 
 namespace Yoast\Test_Helper;
 
+/**
+ * Class to add an inline script after a wordpress-seo script.
+ */
 class Inline_Script implements Integration {
 	/**
 	 * Holds our option instance.
@@ -30,7 +33,7 @@ class Inline_Script implements Integration {
 	 * @return void
 	 */
 	public function add_hooks() {
-		if( $this->option->get( 'add_inline_script' ) == true ) {
+		if ( $this->option->get( 'add_inline_script' ) === true ) {
 			add_action( 'admin_enqueue_scripts', array( $this, 'add_inline_script' ) );
 		}
 
@@ -53,18 +56,21 @@ class Inline_Script implements Integration {
 	 * @return string The HTML to use to render the controls.
 	 */
 	public function get_controls() {
-		$output  = Form_Presenter::create_checkbox(
+		$output = Form_Presenter::create_checkbox(
 			'add_inline_script', 'Add the specified inline script',
 			$this->option->get( 'add_inline_script' )
 		);
 
 		$value = $this->option->get( 'inline_script_handle' );
+
 		$output .= '<label for="inline_script_handle">Handle: </label>';
 		$output .= '<input value="' . $value . '" name="inline_script_handle" id="inline_script_handle"/><br/>';
 
 		$value = $this->option->get( 'inline_script' );
+
 		$output .= '<label for="inline_script">Script:</label><br/>';
 		$output .= '<textarea style="width: 100%; min-height: 300px; font-family: monospace;" name="inline_script" id="inline_script">' . stripslashes( $value ) . '</textarea><br/>';
+
 		return Form_Presenter::get_html( 'Inline script', 'yoast_seo_test_inline_script', $output );
 	}
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -86,6 +86,7 @@ class Plugin implements Integration {
 		$this->integrations[] = new Post_Types( $option );
 		$this->integrations[] = new Taxonomies( $option );
 		$this->integrations[] = new XML_Sitemaps( $option );
+		$this->integrations[] = new Inline_Script( $option );
 	}
 
 	/**


### PR DESCRIPTION
@dariaknl Needed an easy way to test javascript hooks.

This PR adds the following to the yoast test helper page:

<img width="648" alt="screen shot 2018-09-13 at 14 19 11" src="https://user-images.githubusercontent.com/5389513/45487941-1dd45c00-b760-11e8-9ffb-3e4e7d918204.png">

Test instuctions:

- You can mimic the above settings to see the duration text filter be applied in the gutenberg how-to block.
```
// Adds a duration text filter to the how to block.
alert( "Reminder: Yoast Test Helper adds an inline script." );

window.wp.hooks.addFilter( "wpseo_duration_text", "my-awesome-plugin", () => {
	console.log( "Filter called" );
	return "Random3";
} );
```
- Open gutenberg, add an how to block and click `Add duration`.
- `Time needed:` Should be replaced with `Random3`.