### PR TITLE
Grunt command "update-version-release" not found

### DIFF
--- a/grunt/config/aliases.yaml
+++ b/grunt/config/aliases.yaml
@@ -2,7 +2,7 @@
 ---
 # Create a zipped artifact from a fresh build
 'artifact':
-  - 'update-version'
+  - 'update-version-trunk'
   - 'clean:artifact'
   - 'clean:artifact-zip'
   - 'clean:vendor'
@@ -10,6 +10,11 @@
   - 'copy:artifact'
   - 'compress:artifact'
   - 'shell:composerInstall'
+
+# Update all versions except the stable tag
+'update-version-trunk':
+  - 'update-version:pluginFile'
+  - 'update-version:initializer'
 
 # Create a zipped artifact from and do not keep the artifact folder
 'artifact:zip':
@@ -22,6 +27,6 @@
   - 'wp_deploy:trunk'
 
 'deploy:master':
-  - 'update-version-release'
+  - 'update-version'
   - 'create:artifact'
   - 'wp_deploy:master'

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "grunt-contrib-copy": "^1.0.0",
     "grunt-shell": "^2.1.0",
     "grunt-wp-deploy": "^1.2.1",
-    "grunt-yoast-tasks": "https://github.com/Yoast/plugin-grunt-tasks#1-Create-grunt-plugin-for-custom-tasks",
+    "@yoast/grunt-plugin-tasks": "^1.0.0",
     "jit-grunt": "^0.10.0",
     "load-grunt-config": "^0.19.2",
     "time-grunt": "^1.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"@yoast/grunt-plugin-tasks@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@yoast/grunt-plugin-tasks/-/grunt-plugin-tasks-1.0.0.tgz#647261449f9f5a90014c5310cfb050db47d22202"
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -625,10 +629,6 @@ grunt-wp-deploy@^1.2.1:
   resolved "https://registry.yarnpkg.com/grunt-wp-deploy/-/grunt-wp-deploy-1.2.1.tgz#7d5c284157a181c106c45be052ba9aa71a3c2474"
   dependencies:
     inquirer "~0.2.1"
-
-"grunt-yoast-tasks@https://github.com/Yoast/plugin-grunt-tasks#1-Create-grunt-plugin-for-custom-tasks":
-  version "0.1.0"
-  resolved "https://github.com/Yoast/plugin-grunt-tasks#6f2f15f73c2c5a4da741d10d6e6ef00d51abe354"
 
 grunt@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Updating the yoast-plugin-tasks package to the npm one.
* Adding a new command to the aliasses file.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Run the grunt commands `grunt artifact` and `grunt deploy:master` and look if the behavior is similar to what is descibed in the [issue](#30 )

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #30 