### PR TITLE
Add groups to plugin toggler

### DIFF
--- a/assets/js/yoast-toggle.js
+++ b/assets/js/yoast-toggle.js
@@ -1,16 +1,17 @@
 var Yoast_Plugin_Toggler = {
-	toggle_plugin: function( plugin, nonce ) {
+	toggle_plugin: function( group, plugin, nonce ) {
 		"use strict";
 
 		jQuery.getJSON(
 			ajaxurl,
 			{
-				action: "toggle_version",
+				action: "toggle_plugin",
 				ajax_nonce: nonce,
+				group: group,
 				plugin: plugin
 			},
 			function( response ) {
-				if ( response.activated_version !== undefined ) {
+				if ( response.activated_plugin !== undefined ) {
 					window.location.reload(true);
 				}
 			}

--- a/src/Plugin_Toggler.php
+++ b/src/Plugin_Toggler.php
@@ -85,14 +85,7 @@ class Plugin_Toggler implements Integration {
 		// Apply filters to adapt the $this->grouped_name_filter property.
 		$this->grouped_name_filter = apply_filters( 'yoast_plugin_toggler_filter', $this->grouped_name_filter );
 
-		// Find the plugin groups.
-		$this->plugin_groups = $this->get_plugin_groups();
-
-		// Apply filters to extend the $this->plugin_groups property.
-		$this->plugin_groups = (array) apply_filters( 'yoast_plugin_toggler_extend', $this->plugin_groups );
-
-		// Check the plugins after the filter.
-		$this->plugin_groups = $this->check_plugins( $this->plugin_groups );
+		$this->init_plugin_groups();
 
 		// Adding the hooks.
 		$this->add_additional_hooks();
@@ -265,7 +258,7 @@ class Plugin_Toggler implements Integration {
 
 		foreach ( $plugins as $file => $data ) {
 			$plugin = $data[ 'Name' ];
-			$group  = $this->get_group_from_plugin_name( $plugin, $this->grouped_name_filter );
+			$group  = $this->get_group_from_plugin_name( $plugin );
 			if ( $group === '' ) {
 				continue;
 			}
@@ -287,14 +280,13 @@ class Plugin_Toggler implements Integration {
 	 * $grouped_name_filter = '/^(Yoast SEO)$|^(Yoast SEO)[^:]{1}/'
 	 *
 	 * @param string $plugin_name         The plugin name.
-	 * @param string $grouped_name_filter The regex string that matches the group.
 	 *
 	 * @return string The group.
 	 */
-	private function get_group_from_plugin_name( $plugin_name, $grouped_name_filter ) {
+	private function get_group_from_plugin_name( $plugin_name ) {
 		$matches = array();
 
-		if ( preg_match( $grouped_name_filter, $plugin_name, $matches ) ) {
+		if ( preg_match( $this->grouped_name_filter, $plugin_name, $matches ) ) {
 			foreach ( $matches as $match ) {
 				if ( $match !== '' ) {
 					return trim( $match );
@@ -429,5 +421,21 @@ class Plugin_Toggler implements Integration {
 		if ( wp_verify_nonce( $ajax_nonce, 'yoast-plugin-toggle' ) ) {
 			return true;
 		}
+	}
+
+	/**
+	 * Initializes the plugin groups.
+	 *
+	 * @return void
+	 */
+	private function init_plugin_groups() {
+		// Find the plugin groups.
+		$plugin_groups = $this->get_plugin_groups();
+
+		// Apply filters to extend the $this->plugin_groups property.
+		$plugin_groups = (array) apply_filters( 'yoast_plugin_toggler_extend', $plugin_groups );
+
+		// Check the plugins after the filter.
+		$this->plugin_groups = $this->check_plugins( $plugin_groups );
 	}
 }


### PR DESCRIPTION
## Why?
Due to my habit of adding releases to the plugins directory. I was hoping to extend this plugin to include them in the toggle menu.

## What?
I found out this toggles between two in a namespace. I did not want to write a separate plugin to extend the array every time. So instead it now scans all the plugins and filters them by name and groups them by the regex groups.
There can now be more than 2 plugins per group. Still only 1 active plugin per group.

**Plugins folder**
<img width="199" alt="plugins" src="https://user-images.githubusercontent.com/35524806/42722850-a97028b2-8753-11e8-9948-d78817f58a8f.png">
**The toggle menu**
<img width="245" alt="menu" src="https://user-images.githubusercontent.com/35524806/42722851-ab0552e2-8753-11e8-8caa-019e388ffc81.png">

## Changes
- Initializes the plugins array with WordPress's `get_plugins` filtered by name and grouped according to the regex.
- Added the filter `yoast_plugin_toggler_filter` to alter the `grouped_name_filter` regex.
- Implemented support for more than 2 plugins per group.

## Test
Have multiple plugins that start with `Yoast SEO` and/or `Yoast SEO Premium`.
- They are grouped under one menu.
- When no plugins are active the group is called `Yoast SEO`.
- When a plugin is active the group is called as that active plugin.
- When a plugin is active it does not appear in the drop-down. With the exception of when multiple plugins are active, then it behaves as if only the first found is active.
- When clicking on a plugin in the drop-down it deactivates all in the group that are active and then activates the plugin you clicked on.
- Exposes the filter `yoast_plugin_toggler_filter` that lets you alter the grouping regex.
- Exposes the filter `yoast_plugin_toggler_extend` that lets you alter the plugin groups. This will not let you add uninstalled plugins or groups with less than 2 plugins.
