### PR TITLE
Add schema filters

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -5,6 +5,7 @@
     <file>.</file>
 
     <exclude-pattern>vendor/*</exclude-pattern>
+    <exclude-pattern>node_modules/*</exclude-pattern>
 
     <arg name="extensions" value="php"/>
     <arg value="sp"/>

--- a/src/Form_Presenter.php
+++ b/src/Form_Presenter.php
@@ -70,7 +70,7 @@ class Form_Presenter {
 		$output .= sprintf( '<select name="%1$s" id="%1$s">', $option );
 		foreach ( $options as $value => $option_label ) {
 			$selected_html = selected( $selected === $value, true, false );
-			$output .= sprintf( '<option ' . $selected_html . ' value="%1$s">%2$s</option>', $value, $option_label );
+			$output       .= sprintf( '<option ' . $selected_html . ' value="%1$s">%2$s</option>', $value, $option_label );
 		}
 		$output .= '</select><br/>';
 

--- a/src/Form_Presenter.php
+++ b/src/Form_Presenter.php
@@ -54,4 +54,26 @@ class Form_Presenter {
 
 		return $output;
 	}
+
+	/**
+	 * Build a select element.
+	 *
+	 * @param string   $option   The option to make a checkbox for.
+	 * @param string   $label    The label for the checkbox.
+	 * @param string[] $options  The options of the select.
+	 * @param bool     $selected The selected option.
+	 *
+	 * @return string The select & label HTML.
+	 */
+	public static function create_select( $option, $label, $options, $selected = false ) {
+		$output  = sprintf( '<label for="%1$s">%2$s</label>', $option, $label );
+		$output .= sprintf( '<select name="%1$s" id="%1$s">', $option );
+		foreach ( $options as $value => $option_label ) {
+			$selected_html = selected( $selected === $value, true, false );
+			$output .= sprintf( '<option ' . $selected_html . ' value="%1$s">%2$s</option>', $value, $option_label );
+		}
+		$output .= '</select><br/>';
+
+		return $output;
+	}
 }

--- a/src/Plugin_Toggler.php
+++ b/src/Plugin_Toggler.php
@@ -141,8 +141,8 @@ class Plugin_Toggler implements Integration {
 							$group,
 							$plugin,
 							$nonce
-						)
-					)
+						),
+					),
 				) );
 			}
 		}
@@ -185,8 +185,8 @@ class Plugin_Toggler implements Integration {
 			$response = array(
 				'activated_plugin' => array(
 					'group'  => $group,
-					'plugin' => $plugin
-				)
+					'plugin' => $plugin,
+				),
 			);
 		}
 
@@ -241,12 +241,12 @@ class Plugin_Toggler implements Integration {
 	 * Example:
 	 * $this->grouped_name_filter = '/^(Yoast SEO)$|^(Yoast SEO)[^:]{1}/'
 	 * $plugin_groups = array(
-	 * 	'Yoast SEO' => array(
-	 * 		'Yoast SEO'             => 'wordpress-seo/wp-seo.php',
-	 * 		'Yoast SEO 8.4'         => 'wordpress-seo 8.4/wp-seo.php',
-	 * 		'Yoast SEO Premium'     => 'wordpress-seo-premium/wp-seo-premium.php',
-	 * 		'Yoast SEO Premium 8.4' => 'wordpress-seo-premium 8.4/wp-seo-premium.php',
-	 * 	),
+	 *   'Yoast SEO' => array(
+	 *     'Yoast SEO'             => 'wordpress-seo/wp-seo.php',
+	 *     'Yoast SEO 8.4'         => 'wordpress-seo 8.4/wp-seo.php',
+	 *     'Yoast SEO Premium'     => 'wordpress-seo-premium/wp-seo-premium.php',
+	 *     'Yoast SEO Premium 8.4' => 'wordpress-seo-premium 8.4/wp-seo-premium.php',
+	 *   ),
 	 * );
 	 *
 	 * @return array The plugins grouped by the regex matches.
@@ -257,7 +257,7 @@ class Plugin_Toggler implements Integration {
 		$plugin_groups = array();
 
 		foreach ( $plugins as $file => $data ) {
-			$plugin = $data[ 'Name' ];
+			$plugin = $data['Name'];
 			$group  = $this->get_group_from_plugin_name( $plugin );
 			if ( $group === '' ) {
 				continue;
@@ -301,7 +301,7 @@ class Plugin_Toggler implements Integration {
 	 * Retrieves a list of installed plugins, pruned by group.
 	 *
 	 * @param array $plugin_groups Plugins to filter for installed plugins.
-	 * @param bool  [$prune=true]  Whether to prune the groups if they contain less than 2 plugins.
+	 * @param bool  $prune         Whether to prune the groups if they contain less than 2 plugins. Defaults to true.
 	 *
 	 * @return array Plugins that are actually installed.
 	 */
@@ -396,12 +396,12 @@ class Plugin_Toggler implements Integration {
 	 * @return void
 	 */
 	private function deactivate_plugin_group( $group ) {
-		if ( ! array_key_exists( $group, $this->plugin_groups ) )  {
+		if ( ! array_key_exists( $group, $this->plugin_groups ) ) {
 			return;
 		}
 
 		$plugins = $this->plugin_groups[ $group ];
-		foreach( $plugins as $plugin => $plugin_path ) {
+		foreach ( $plugins as $plugin => $plugin_path ) {
 			if ( is_plugin_active( $plugin_path ) ) {
 				deactivate_plugins( plugin_basename( $plugin_path ), true );
 			}

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -37,13 +37,15 @@ class Schema implements Integration {
 
 		if ( $this->option->get( 'is_needed_breadcrumb' ) === 'none' ) {
 			remove_filter( 'wpseo_schema_needs_breadcrumb', array( $this, 'filter_is_needed_breadcrumb' ) );
-		} else {
+		}
+		else {
 			add_filter( 'wpseo_schema_needs_breadcrumb', array( $this, 'filter_is_needed_breadcrumb' ) );
 		}
 
 		if ( $this->option->get( 'is_needed_webpage' ) === 'none' ) {
 			remove_filter( 'wpseo_schema_needs_webpage', array( $this, 'filter_is_needed_webpage' ) );
-		} else {
+		}
+		else {
 			add_filter( 'wpseo_schema_needs_webpage', array( $this, 'filter_is_needed_webpage' ) );
 		}
 
@@ -112,7 +114,7 @@ class Schema implements Integration {
 		$source = \WPSEO_Utils::get_home_url();
 		$target = 'https://example.com';
 
-		if ( $source[ strlen( $source ) - 1 ] === '/' ) {
+		if ( $source[ ( strlen( $source ) - 1 ) ] === '/' ) {
 			$source = substr( $source, 0, -1 );
 		}
 

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -65,7 +65,7 @@ class Schema implements Integration {
 		$select_options = array(
 			'none' => 'Don\'t influence',
 			'show' => 'Always include',
-			'hide' => 'Always hide',
+			'hide' => 'Never include',
 		);
 
 		$output .= Form_Presenter::create_select(

--- a/src/WordPress_Plugins/Yoast_SEO.php
+++ b/src/WordPress_Plugins/Yoast_SEO.php
@@ -146,7 +146,7 @@ class Yoast_SEO implements WordPress_Plugin {
 		$wpdb->delete( $wpdb->prefix . 'usermeta',
 			array(
 				'meta_key' => 'wp_yoast_notifications',
-				'user_id' => get_current_user_id(),
+				'user_id'  => get_current_user_id(),
 			)
 		);
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Added filters for the Breadcrumb and WebPage Graphs.

## Relevant technical choices:

* Added selection creation helper.
* 3 choices: `Don't influence`, `Always include` and `Never include`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Switch to this branch.
* Activate the plugin in WP.
* Go to the `Tools -> Yoast Test` page.
<img width="668" alt="is_needed" src="https://user-images.githubusercontent.com/35524806/56897622-4b6fda80-6a8f-11e9-86bf-ef0f58039bfb.png">

* Go to a WP output post/page/whatever, open the source and copy the JSON+LD script.
* [Use Google's SDTT](https://search.google.com/structured-data/testing-tool/u/0/) to test the _stitching_.
* Try different values and check if the schema output matches.
	* `Don't influence` should result in the same output as without the plugin installed.
	* `Always include` is a bit harder to verify with some options. But you can go to `SEO -> Search Appearance -> Breadcrumbs` and disable the breadcrumbs output. Note this is now not _stitched_ anymore due to not being linked in the webpage.
	* `Never include` will also result in strange _stitch_ situations.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #35