### PR TITLE
Add IDs to the buttons

### DIFF
--- a/src/Form_Presenter.php
+++ b/src/Form_Presenter.php
@@ -22,15 +22,16 @@ class Form_Presenter {
 	 * @return string The HTML to render the form.
 	 */
 	public static function get_html( $title, $nonce_field, $fields, $submit = true ) {
+		$field   = esc_attr( $nonce_field );
 		$output  = '<h2>' . esc_html( $title ) . '</h2>';
 		$output .= '<form action="' . esc_url( admin_url( 'admin-post.php' ) ) . '" method="POST">';
 		$output .= wp_nonce_field( $nonce_field, '_wpnonce', true, false );
-		$output .= '<input type="hidden" name="action" value="' . esc_attr( $nonce_field ) . '">';
+		$output .= '<input type="hidden" name="action" value="' . $field . '">';
 
 		$output .= $fields;
 
 		if ( $submit ) {
-			$output .= '<button class="button" type="submit">Save</button>';
+			$output .= '<button id="' . $field .'_save" class="button" type="submit">Save</button>';
 		}
 
 		$output .= '</form>';

--- a/src/Form_Presenter.php
+++ b/src/Form_Presenter.php
@@ -31,7 +31,7 @@ class Form_Presenter {
 		$output .= $fields;
 
 		if ( $submit ) {
-			$output .= '<button id="' . $field .'_save" class="button" type="submit">Save</button>';
+			$output .= '<button id="' . $field . '_save" class="button" type="submit">Save</button>';
 		}
 
 		$output .= '</form>';

--- a/src/WordPress_Plugin_Features.php
+++ b/src/WordPress_Plugin_Features.php
@@ -73,7 +73,8 @@ class WordPress_Plugin_Features implements Integration {
 			'', array_map(
 				function ( $name, $feature ) {
 					return sprintf(
-						'<button name="%s" type="submit" class="button">Reset %s</button> ',
+						'<button id="%s" name="%s" type="submit" class="button">Reset %s</button> ',
+						$feature . '_button',
 						$feature,
 						$name
 					);


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds IDs to the buttons.

## Relevant technical choices:

* Using the nonce field as name since those make sense already. Then adding `_save` suffix for the forms and `_button` in the features.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Check if the save buttons have valid IDs that end with `_save`.
* Check if the reset buttons have valid IDs that end with `_button`.
* Check if the buttons still work.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
