### PR TITLE
Add Development mode toggle

### DIFF
--- a/src/Development_Mode.php
+++ b/src/Development_Mode.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Handle admin notifications.
+ *
+ * @package Yoast\Test_Helper
+ */
+
+namespace Yoast\Test_Helper;
+
+/**
+ * Shows admin notifications on the proper page.
+ */
+class Development_Mode implements Integration {
+
+	/**
+	 * Holds our option instance.
+	 *
+	 * @var Option
+	 */
+	private $option;
+
+	/**
+	 * Class constructor.
+	 *
+	 * @param Option $option Our option array.
+	 */
+	public function __construct( Option $option ) {
+		$this->option = $option;
+	}
+
+	/**
+	 * Enabling this plugin means you are in development mode.
+	 *
+	 * @return void
+	 */
+	public function add_hooks() {
+		if ( $this->option->get( 'enable_development_mode' ) ) {
+			add_filter( 'yoast_seo_development_mode', '__return_true' );
+		}
+
+		add_action( 'admin_post_yoast_seo_test_development_mode', array( $this, 'handle_submit' ) );
+	}
+
+	/**
+	 * Retrieves the controls.
+	 *
+	 * @return string The HTML to use to render the controls.
+	 */
+	public function get_controls() {
+		$fields = Form_Presenter::create_checkbox(
+			'enable_development_mode',
+			'Enable development mode.',
+			$this->option->get( 'enable_development_mode' )
+		);
+
+		return Form_Presenter::get_html( 'Enable development mode', 'yoast_seo_test_development_mode', $fields );
+	}
+
+	/**
+	 * Handles the form submit.
+	 *
+	 * @return void
+	 */
+	public function handle_submit() {
+		if ( check_admin_referer( 'yoast_seo_test_development_mode' ) !== false ) {
+			$this->set_bool_option( 'enable_development_mode' );
+		}
+
+		wp_safe_redirect( self_admin_url( 'tools.php?page=' . apply_filters( 'yoast_version_control_admin_page', '' ) ) );
+	}
+
+	/**
+	 * Sets a boolean option based on a POST parameter.
+	 *
+	 * @param string $option The option to check and set.
+	 */
+	private function set_bool_option( $option ) {
+		// The nonce is checked in the handle_submit function.
+		// phpcs:ignore WordPress.CSRF.NonceVerification.NoNonceVerification
+		$this->option->set( $option, isset( $_POST[ $option ] ) );
+	}
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -39,9 +39,6 @@ class Plugin implements Integration {
 	 * @return void
 	 */
 	public function add_hooks() {
-		// Enabling this plugin means you are in development mode.
-		add_filter( 'yoast_seo_development_mode', '__return_true' );
-
 		array_map(
 			function ( Integration $integration ) {
 				$integration->add_hooks();
@@ -80,6 +77,7 @@ class Plugin implements Integration {
 		$option = new Option();
 
 		$this->integrations[] = $plugin_version_control;
+		$this->integrations[] = new Development_Mode( $option );
 		$this->integrations[] = new Admin_Notifications();
 		$this->integrations[] = new Upgrade_Detector();
 		$this->integrations[] = new Admin_Page();

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -39,6 +39,9 @@ class Plugin implements Integration {
 	 * @return void
 	 */
 	public function add_hooks() {
+		// Enabling this plugin means you are in development mode.
+		add_filter( 'yoast_seo_development_mode', '__return_true' );
+
 		array_map(
 			function ( Integration $integration ) {
 				$integration->add_hooks();


### PR DESCRIPTION

<img width="1351" alt="Screenshot 2020-02-03 at 21 39 43" src="https://user-images.githubusercontent.com/487629/73689121-cbd20480-46cd-11ea-84bd-2f36fffb0ef2.png">

When turned on, this filters `yoast_seo_development_mode` to `true`, which means every call to `WPSEO_Utils::is_development_mode` will return true and thus enables development mode.