### PR TITLE
Allow running the Yoast SEO Premium upgrade routine

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -12,6 +12,7 @@ use Yoast\Test_Helper\WordPress_Plugins\News_SEO;
 use Yoast\Test_Helper\WordPress_Plugins\Video_SEO;
 use Yoast\Test_Helper\WordPress_Plugins\WooCommerce_SEO;
 use Yoast\Test_Helper\WordPress_Plugins\Yoast_SEO;
+use Yoast\Test_Helper\WordPress_Plugins\Yoast_SEO_Premium;
 
 /**
  * Bootstrap for the entire plugin.
@@ -101,6 +102,7 @@ class Plugin implements Integration {
 	private function get_plugins() {
 		return array(
 			new Yoast_SEO(),
+			new Yoast_SEO_Premium(),
 			new Local_SEO(),
 			new Video_SEO(),
 			new News_SEO(),

--- a/src/Upgrade_Detector.php
+++ b/src/Upgrade_Detector.php
@@ -17,7 +17,8 @@ class Upgrade_Detector implements Integration {
 	 * @return void
 	 */
 	public function add_hooks() {
-		add_action( 'wpseo_run_upgrade', array( $this, 'add_upgrade_ran_notification' ) );
+		add_action( 'wpseo_run_upgrade', array( $this, 'yoast_seo_upgrade_ran' ) );
+		add_action( 'update_option_wpseo_premium_version', array( $this, 'yoast_seo_premium_upgrade_ran' ) );
 	}
 
 	/**
@@ -25,8 +26,28 @@ class Upgrade_Detector implements Integration {
 	 *
 	 * @return void
 	 */
-	public function add_upgrade_ran_notification() {
-		$notification = new Notification( 'The WPSEO upgrade routine was executed.', 'success' );
+	public function yoast_seo_upgrade_ran() {
+		$this->add_notification( 'The Yoast SEO upgrade routine was executed.' );
+	}
+
+	/**
+	 * Adds the notification to the stack.
+	 *
+	 * @return void
+	 */
+	public function yoast_seo_premium_upgrade_ran() {
+		$this->add_notification( 'The Yoast SEO Premium upgrade routine was executed.' );
+	}
+
+	/**
+	 * Adds a success notitifcation for an upgrade.
+	 *
+	 * @param string $notification_text The notification text to show.
+	 *
+	 * @return void
+	 */
+	private function add_notification( $notification_text ) {
+		$notification = new Notification( $notification_text, 'success' );
 		do_action( 'yoast_version_controller_notification', $notification );
 	}
 }

--- a/src/Upgrade_Detector.php
+++ b/src/Upgrade_Detector.php
@@ -36,7 +36,7 @@ class Upgrade_Detector implements Integration {
 	 * @return void
 	 */
 	public function yoast_seo_premium_upgrade_ran() {
-		$this->add_notification( 'The Yoast SEO Premium upgrade routine was executed.' );
+		$this->add_notification( 'Yoast SEO Premium updated its version number, which should mean the upgrade routine was executed.' );
 	}
 
 	/**

--- a/src/WordPress_Plugin_Version.php
+++ b/src/WordPress_Plugin_Version.php
@@ -45,6 +45,10 @@ class WordPress_Plugin_Version {
 			return false;
 		}
 
+		if ( $plugin->get_version_key() === '' ) {
+			return update_option( $plugin->get_version_option_name(), $version );
+		}
+
 		if ( $data[ $plugin->get_version_key() ] === $version ) {
 			return false;
 		}

--- a/src/WordPress_Plugin_Version_Control.php
+++ b/src/WordPress_Plugin_Version_Control.php
@@ -155,7 +155,12 @@ class WordPress_Plugin_Version_Control implements Integration {
 			implode(
 				'', array_map(
 					function ( $timestamp, $item ) use ( $plugin ) {
-						$version = $item[ $plugin->get_version_option_name() ][ $plugin->get_version_key() ];
+						if ( $plugin->get_version_key() !== '' ) {
+							$version = $item[ $plugin->get_version_option_name() ][ $plugin->get_version_key() ];
+						}
+						else {
+							$version = $item[ $plugin->get_version_option_name() ];
+						}
 
 						return sprintf(
 							'<option value="%s">(%s) %s</option>', esc_attr( $timestamp ),

--- a/src/WordPress_Plugins/Yoast_SEO_Premium.php
+++ b/src/WordPress_Plugins/Yoast_SEO_Premium.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Local SEO plugin.
+ *
+ * @package Yoast\Test_Helper
+ */
+
+namespace Yoast\Test_Helper\WordPress_Plugins;
+
+use WPSEO_Premium;
+
+/**
+ * Class to represent Local SEO.
+ */
+class Yoast_SEO_Premium implements WordPress_Plugin {
+	/**
+	 * Retrieves the plugin identifier.
+	 *
+	 * @return string The plugin identifier.
+	 */
+	public function get_identifier() {
+		return 'wordpress-seo-premium';
+	}
+
+	/**
+	 * Retrieves the plugin name.
+	 *
+	 * @return string The name of the plugin.
+	 */
+	public function get_name() {
+		return 'Yoast SEO Premium';
+	}
+
+	/**
+	 * Retrieves the version option name.
+	 *
+	 * @return string The name that holds the version.
+	 */
+	public function get_version_option_name() {
+		return 'wpseo_premium_version';
+	}
+
+	/**
+	 * Retrieves the version key.
+	 *
+	 * @return string The version key.
+	 */
+	public function get_version_key() {
+		return '';
+	}
+
+	/**
+	 * Retrieves the options.
+	 *
+	 * @return array The options.
+	 */
+	public function get_options() {
+		return array( $this->get_version_option_name() );
+	}
+
+	/**
+	 * Resets a feature.
+	 *
+	 * @param string $feature Feature to reset.
+	 *
+	 * @return bool True on succes.
+	 */
+	public function reset_feature( $feature ) {
+		return false;
+	}
+
+	/**
+	 * Retrieves the list of features.
+	 *
+	 * @return array List of features.
+	 */
+	public function get_features() {
+		return array();
+	}
+
+	/**
+	 * Retrieves the active version of the plugin.
+	 *
+	 * @return string The current version of the plugin.
+	 */
+	public function get_version_constant() {
+		return defined( 'WPSEO_Premium::PLUGIN_VERSION_NAME' ) ? WPSEO_Premium::PLUGIN_VERSION_NAME : 'not active';
+	}
+}


### PR DESCRIPTION
This adds the option to set the Yoast SEO Premium database version, and thus the option to make the upgrade routine run. It also adds a notification when that upgrade routine has run.

Known caveats: this doesn't _actually_ know whether the premium upgrade routine has fired, since there's no hook in premium to test for this, so it fires when the option is updated, which happens after the upgrade routines run, hence this message:

![Screenshot 2020-02-04 at 13 36 17](https://user-images.githubusercontent.com/487629/73745464-5d378a00-4753-11ea-9081-40c8ccfac773.png)
 
Fixes #58 