### PR TITLE
Add a reset indexable migrations feature

### DIFF
--- a/src/wordpress-plugin-features.php
+++ b/src/wordpress-plugin-features.php
@@ -71,9 +71,9 @@ class WordPress_Plugin_Features implements Integration {
 				function ( $name, $feature ) {
 					return sprintf(
 						'<button id="%s" name="%s" type="submit" class="button secondary">Reset %s</button> ',
-						$feature . '_button',
-						$feature,
-						$name
+						esc_attr( $feature ) . '_button',
+						esc_attr( $feature ),
+						esc_html( $name )
 					);
 				},
 				$features,

--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -210,7 +210,7 @@ class Yoast_SEO implements WordPress_Plugin {
 		$wpdb->query( 'DROP TABLE ' . $wpdb->prefix . 'yoast_indexable_hierarchy' );
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.SchemaChange -- We're doing.
 		$wpdb->query( 'DROP TABLE ' . $wpdb->prefix . 'yoast_migrations' );
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.SchemaChange -- We're doing.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.SchemaChange -- Really.
 		$wpdb->query( 'DROP TABLE ' . $wpdb->prefix . 'yoast_primary_term' );
 
 		return delete_option( 'yoast_migrations_free' );

--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -75,6 +75,7 @@ class Yoast_SEO implements WordPress_Plugin {
 			'reset_notifications'         => 'Notifications',
 			'reset_site_information'      => 'Site information',
 			'reset_tracking'              => 'Tracking',
+			'reset_indexables'            => 'Indexables tables & migrations',
 		];
 	}
 
@@ -95,6 +96,8 @@ class Yoast_SEO implements WordPress_Plugin {
 				return true;
 			case 'reset_configuration_wizard':
 				return $this->reset_configuration_wizard();
+			case 'reset_indexables':
+				return $this->reset_indexables();
 			case 'reset_notifications':
 				$this->reset_notifications();
 				return true;
@@ -189,6 +192,25 @@ class Yoast_SEO implements WordPress_Plugin {
 	 */
 	private function reset_configuration_wizard() {
 		update_user_meta( get_current_user_id(), 'wpseo-dismiss-configuration-notice', 'no' );
+
 		return WPSEO_Options::set( 'show_onboarding_notice', true );
+	}
+
+	/**
+	 * Resets the indexables tables, basically deleting them.
+	 *
+	 * @return bool True if successful, false otherwise.
+	 */
+	private function reset_indexables() {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.SchemaChange -- We know.
+		$wpdb->query( 'DROP TABLE ' . $wpdb->prefix . 'yoast_indexable' );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.SchemaChange -- What.
+		$wpdb->query( 'DROP TABLE ' . $wpdb->prefix . 'yoast_indexable_hierarchy' );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.SchemaChange -- We're doing.
+		$wpdb->query( 'DROP TABLE ' . $wpdb->prefix . 'yoast_migrations' );
+
+		return delete_option( 'yoast_migrations_free' );
 	}
 }

--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -210,6 +210,8 @@ class Yoast_SEO implements WordPress_Plugin {
 		$wpdb->query( 'DROP TABLE ' . $wpdb->prefix . 'yoast_indexable_hierarchy' );
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.SchemaChange -- We're doing.
 		$wpdb->query( 'DROP TABLE ' . $wpdb->prefix . 'yoast_migrations' );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.SchemaChange -- We're doing.
+		$wpdb->query( 'DROP TABLE ' . $wpdb->prefix . 'yoast_primary_term' );
 
 		return delete_option( 'yoast_migrations_free' );
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Add a reset indexable migrations feature

## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

This PR can be tested by following these steps:

* Have a site that runs on Yoast SEO master.
* Upgrade it to indexables, see the new tables in your database.
* Hit the new "Reset indexables tables & migrations" button in Yoast test helper, see those tables are gone.
