### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,30 @@
+#
+# Exclude these files from release archives.
+# This will also make them unavailable when using Composer with `--prefer-dist`.
+# https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production
+# https://blog.madewithlove.be/post/gitattributes/
+#
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+Gruntfile.js export-ignore
+package.json export-ignore
+phpcs.xml.dist export-ignore
+phpunit.xml.dist export-ignore
+/.github export-ignore
+/deploy_keys export-ignore
+/grunt export-ignore
+/scripts export-ignore
+/svn-assets export-ignore
+
+#
+# Auto detect text files and perform LF normalization
+# http://davidlaing.com/2012/09/19/customise-your-gitattributes-to-become-a-git-ninja/
+#
+* text=auto
+
+#
+# The above will handle all files NOT found below
+#
+*.md text
+*.php text


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Cleaner release files on GitHub and Packagist

## Relevant technical choices:

Add `.gitattributes` file to keep distribution zips clean of dev-only files.

## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

This PR can be tested by following these steps:

* _N/A_ 

Well, if someone insists: 
* Download the standard GH zip from the latest release: https://github.com/Yoast/yoast-test-helper/archive/1.5.0.zip
* Open the zip and take note of all the dev/CI files in it.
* Download the zip for this branch: https://github.com/Yoast/yoast-test-helper/archive/JRF/add-gitattributes-file.zip
* Open the zip and take note that the dev/CI files are no longer included.

This will also apply to downloads of the package via Packagist once the plugin is registered there. (I noticed it isn't yet) /cc @jdevalk @herregroen 