### PR TITLE
Travis: run builds for PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: php
 dist: trusty
-sudo: false
 
 branches:
   only:
     - master
+    - develop
     # Also build tags like 1.1.1 or 1.1 for deployment.
     - /(\d+\.)?(\d+\.)?(\*|\d+)/
 
@@ -53,9 +53,7 @@ before_install:
 install:
 - |
   if [[ "$PHPCS" == "1" ]]; then
-    if [[ $TRAVIS_PHP_VERSION == "5.6" ]]; then phpenv local 5.6.13; fi
     composer install --no-interaction
-    if [[ $TRAVIS_PHP_VERSION == "5.6" ]]; then phpenv local --unset; fi
   fi
 
 before_script:
@@ -84,7 +82,7 @@ script:
 - |
   if [[ "$PHPCS" == "1" ]]; then
     travis_fold start "PHP.code-style" && travis_time_start
-    vendor/bin/phpcs
+    composer check-cs
     travis_time_finish && travis_fold end "PHP.code-style"
   fi
 # Validate the composer.json file.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Improve QA checking

## Relevant technical choices:

Development has switched from `master` to `develop`, but the `develop` branch was not whitelisted in the Travis script, so PRs would not be build.

Includes some additional tweaks:
* Remove `sudo: false`: Travis removed support for `sudo` nearly a year ago.
* Remove two conditions which would always be `false` as the PHPCS build is against PHP 7.4/latest stable.
* Use the `check-cs` Composer script for running PHPCS.


## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

This PR can be tested by following these steps:

* Check that Travis is reporting back on this PR in the merge block and that the build passes.
