### PR TITLE
QA: declare static closures as static

### DIFF
--- a/src/admin-page.php
+++ b/src/admin-page.php
@@ -91,7 +91,7 @@ class Admin_Page implements Integration {
 		$this->masonry_script();
 
 		array_map(
-			function( $block ) {
+			static function( $block ) {
 				echo '<div class="wpseo_test_block">';
 				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				echo $block();

--- a/src/plugin-version-control.php
+++ b/src/plugin-version-control.php
@@ -152,7 +152,7 @@ class Plugin_Version_Control implements Integration {
 			implode(
 				'',
 				array_map(
-					function ( $timestamp, $item ) use ( $plugin ) {
+					static function ( $timestamp, $item ) use ( $plugin ) {
 						$version_option = $plugin->get_version_option_name();
 						$version_key    = $plugin->get_version_key();
 						if ( ! empty( $version_key ) ) {

--- a/src/plugin.php
+++ b/src/plugin.php
@@ -37,7 +37,7 @@ class Plugin implements Integration {
 	 */
 	public function add_hooks() {
 		array_map(
-			function ( Integration $integration ) {
+			static function ( Integration $integration ) {
 				$integration->add_hooks();
 			},
 			$this->integrations

--- a/src/wordpress-plugin-features.php
+++ b/src/wordpress-plugin-features.php
@@ -68,7 +68,7 @@ class WordPress_Plugin_Features implements Integration {
 		$fields = implode(
 			'',
 			array_map(
-				function ( $name, $feature ) {
+				static function ( $name, $feature ) {
 					return sprintf(
 						'<button id="%s" name="%s" type="submit" class="button secondary">Reset %s</button> ',
 						esc_attr( $feature ) . '_button',


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Code consistency.

## Relevant technical choices:

Declare closures which don't use `$this` as `static` for a tiny performance improvement.

## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

This PR can be tested by following these steps:

* _N/A_ No functional changes. Everything should still work the same as before.
