### PR TITLE
QA: add missing import `use` statements for classes

### DIFF
--- a/src/admin-bar-panel.php
+++ b/src/admin-bar-panel.php
@@ -2,10 +2,12 @@
 
 namespace Yoast\WP\Test_Helper;
 
+use Debug_Bar_Panel;
+
 /**
  * Class to manage registering and rendering the admin page in WordPress.
  */
-class Admin_Bar_Panel extends \Debug_Bar_Panel {
+class Admin_Bar_Panel extends Debug_Bar_Panel {
 
 	/**
 	 * Admin_Bar_Debug_Panel constructor.

--- a/src/admin-debug-info.php
+++ b/src/admin-debug-info.php
@@ -2,6 +2,11 @@
 
 namespace Yoast\WP\Test_Helper;
 
+use Admin_Bar_Panel;
+use Yoast\WP\Test_Helper\Form_Presenter;
+use Yoast\WP\Test_Helper\Integration;
+use Yoast\WP\Test_Helper\Option;
+
 /**
  * Class to manage registering and rendering the admin page in WordPress.
  */
@@ -46,7 +51,7 @@ class Admin_Debug_Info implements Integration {
 	 */
 	public function add_debug_panel( $panels ) {
 		if ( $this->option->get( 'show_options_debug' ) === true && defined( 'WPSEO_VERSION' ) ) {
-			$panels[] = new \Admin_Bar_Panel();
+			$panels[] = new Admin_Bar_Panel();
 		}
 		return $panels;
 	}

--- a/src/admin-notifications.php
+++ b/src/admin-notifications.php
@@ -2,6 +2,9 @@
 
 namespace Yoast\WP\Test_Helper;
 
+use Yoast\WP\Test_Helper\Integration;
+use Yoast\WP\Test_Helper\Notification;
+
 /**
  * Shows admin notifications on the proper page.
  */

--- a/src/admin-page.php
+++ b/src/admin-page.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\WP\Test_Helper;
 
+use Yoast\WP\Test_Helper\Integration;
+
 /**
  * Class to manage registering and rendering the admin page in WordPress.
  */

--- a/src/development-mode.php
+++ b/src/development-mode.php
@@ -2,6 +2,10 @@
 
 namespace Yoast\WP\Test_Helper;
 
+use Yoast\WP\Test_Helper\Integration;
+use Yoast\WP\Test_Helper\Form_Presenter;
+use Yoast\WP\Test_Helper\Option;
+
 /**
  * Shows admin notifications on the proper page.
  */

--- a/src/domain-dropdown.php
+++ b/src/domain-dropdown.php
@@ -2,6 +2,10 @@
 
 namespace Yoast\WP\Test_Helper;
 
+use Yoast\WP\Test_Helper\Form_Presenter;
+use Yoast\WP\Test_Helper\Integration;
+use Yoast\WP\Test_Helper\Option;
+
 /**
  * Sends myYoast requests to a chosen testing domain.
  */

--- a/src/feature-toggler.php
+++ b/src/feature-toggler.php
@@ -2,6 +2,10 @@
 
 namespace Yoast\WP\Test_Helper;
 
+use Yoast\WP\Test_Helper\Form_Presenter;
+use Yoast\WP\Test_Helper\Integration;
+use Yoast\WP\Test_Helper\Option;
+
 /**
  * Toggles the features on and off.
  */

--- a/src/inline-script.php
+++ b/src/inline-script.php
@@ -2,6 +2,10 @@
 
 namespace Yoast\WP\Test_Helper;
 
+use Yoast\WP\Test_Helper\Form_Presenter;
+use Yoast\WP\Test_Helper\Integration;
+use Yoast\WP\Test_Helper\Option;
+
 /**
  * Class to add an inline script after a wordpress-seo script.
  */

--- a/src/plugin-toggler.php
+++ b/src/plugin-toggler.php
@@ -2,6 +2,11 @@
 
 namespace Yoast\WP\Test_Helper;
 
+use WPSEO_Utils;
+use Yoast\WP\Test_Helper\Form_Presenter;
+use Yoast\WP\Test_Helper\Integration;
+use Yoast\WP\Test_Helper\Option;
+
 /**
  * Toggles between plugins.
  */
@@ -192,7 +197,7 @@ class Plugin_Toggler implements Integration {
 		}
 
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The util takes care of escaping.
-		echo \WPSEO_Utils::format_json_encode( $response );
+		echo WPSEO_Utils::format_json_encode( $response );
 		die();
 	}
 

--- a/src/plugin-version-control.php
+++ b/src/plugin-version-control.php
@@ -2,6 +2,11 @@
 
 namespace Yoast\WP\Test_Helper;
 
+use Yoast\WP\Test_Helper\Form_Presenter;
+use Yoast\WP\Test_Helper\Integration;
+use Yoast\WP\Test_Helper\Notification;
+use Yoast\WP\Test_Helper\WordPress_Plugin_Options;
+use Yoast\WP\Test_Helper\WordPress_Plugin_Version;
 use Yoast\WP\Test_Helper\WordPress_Plugins\WordPress_Plugin;
 
 /**

--- a/src/plugin.php
+++ b/src/plugin.php
@@ -2,12 +2,31 @@
 
 namespace Yoast\WP\Test_Helper;
 
+use Yoast\WP\Test_Helper\Admin_Debug_Info;
+use Yoast\WP\Test_Helper\Admin_Notifications;
+use Yoast\WP\Test_Helper\Admin_Page;
+use Yoast\WP\Test_Helper\Development_Mode;
+use Yoast\WP\Test_Helper\Domain_Dropdown;
+use Yoast\WP\Test_Helper\Feature_Toggler;
+use Yoast\WP\Test_Helper\Inline_Script;
+use Yoast\WP\Test_Helper\Integration;
+use Yoast\WP\Test_Helper\Option;
+use Yoast\WP\Test_Helper\Post_Types;
+use Yoast\WP\Test_Helper\Plugin_Toggler;
+use Yoast\WP\Test_Helper\Plugin_Version_Control;
+use Yoast\WP\Test_Helper\Schema;
+use Yoast\WP\Test_Helper\Taxonomies;
+use Yoast\WP\Test_Helper\Upgrade_Detector;
+use Yoast\WP\Test_Helper\WordPress_Plugin_Features;
+use Yoast\WP\Test_Helper\WordPress_Plugin_Options;
+use Yoast\WP\Test_Helper\WordPress_Plugin_Version;
 use Yoast\WP\Test_Helper\WordPress_Plugins\Local_SEO;
 use Yoast\WP\Test_Helper\WordPress_Plugins\News_SEO;
 use Yoast\WP\Test_Helper\WordPress_Plugins\Video_SEO;
 use Yoast\WP\Test_Helper\WordPress_Plugins\WooCommerce_SEO;
 use Yoast\WP\Test_Helper\WordPress_Plugins\Yoast_SEO;
 use Yoast\WP\Test_Helper\WordPress_Plugins\Yoast_SEO_Premium;
+use Yoast\WP\Test_Helper\XML_Sitemaps;
 
 /**
  * Bootstrap for the entire plugin.

--- a/src/post-types.php
+++ b/src/post-types.php
@@ -2,6 +2,10 @@
 
 namespace Yoast\WP\Test_Helper;
 
+use Yoast\WP\Test_Helper\Form_Presenter;
+use Yoast\WP\Test_Helper\Integration;
+use Yoast\WP\Test_Helper\Option;
+
 /**
  * Bootstrap for the entire plugin.
  */

--- a/src/schema.php
+++ b/src/schema.php
@@ -2,6 +2,11 @@
 
 namespace Yoast\WP\Test_Helper;
 
+use WPSEO_Utils;
+use Yoast\WP\Test_Helper\Form_Presenter;
+use Yoast\WP\Test_Helper\Integration;
+use Yoast\WP\Test_Helper\Option;
+
 /**
  * Class to manage registering and rendering the admin page in WordPress.
  */
@@ -131,7 +136,7 @@ class Schema implements Integration {
 	 * @return array Data to replace the domain in.
 	 */
 	public function replace_domain( $data ) {
-		$source = \WPSEO_Utils::get_home_url();
+		$source = WPSEO_Utils::get_home_url();
 		$target = 'https://example.com';
 
 		if ( $source[ ( strlen( $source ) - 1 ) ] === '/' ) {

--- a/src/taxonomies.php
+++ b/src/taxonomies.php
@@ -2,6 +2,9 @@
 
 namespace Yoast\WP\Test_Helper;
 
+use Yoast\WP\Test_Helper\Integration;
+use Yoast\WP\Test_Helper\Option;
+
 /**
  * Bootstrap for the entire plugin.
  */

--- a/src/upgrade-detector.php
+++ b/src/upgrade-detector.php
@@ -2,6 +2,9 @@
 
 namespace Yoast\WP\Test_Helper;
 
+use Yoast\WP\Test_Helper\Integration;
+use Yoast\WP\Test_Helper\Notification;
+
 /**
  * Upgrade detector, spawns a notification if an upgrade is being run.
  */

--- a/src/wordpress-plugin-features.php
+++ b/src/wordpress-plugin-features.php
@@ -2,6 +2,9 @@
 
 namespace Yoast\WP\Test_Helper;
 
+use Yoast\WP\Test_Helper\Form_Presenter;
+use Yoast\WP\Test_Helper\Integration;
+use Yoast\WP\Test_Helper\Notification;
 use Yoast\WP\Test_Helper\WordPress_Plugins\WordPress_Plugin;
 
 /**

--- a/src/wordpress-plugin-options.php
+++ b/src/wordpress-plugin-options.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\Test_Helper;
 
+use WPSEO_Options;
 use Yoast\WP\Test_Helper\WordPress_Plugins\WordPress_Plugin;
 
 /**
@@ -140,8 +141,8 @@ class WordPress_Plugin_Options {
 	 */
 	public function unhook_option_sanitization( $option_name ) {
 		// Unhook option sanitization, otherwise the version cannot be changed.
-		if ( class_exists( '\WPSEO_Options' ) ) {
-			$option_instance = \WPSEO_Options::get_option_instance( $option_name );
+		if ( class_exists( WPSEO_Options::class ) ) {
+			$option_instance = WPSEO_Options::get_option_instance( $option_name );
 			remove_filter( 'sanitize_option_' . $option_name, [ $option_instance, 'validate' ] );
 		}
 	}
@@ -154,8 +155,8 @@ class WordPress_Plugin_Options {
 	 * @return void
 	 */
 	public function hook_option_sanitization( $option_name ) {
-		if ( class_exists( '\WPSEO_Options' ) ) {
-			$option_instance = \WPSEO_Options::get_option_instance( $option_name );
+		if ( class_exists( WPSEO_Options::class ) ) {
+			$option_instance = WPSEO_Options::get_option_instance( $option_name );
 			add_filter( 'sanitize_option_' . $option_name, [ $option_instance, 'validate' ] );
 		}
 	}

--- a/src/wordpress-plugin-version.php
+++ b/src/wordpress-plugin-version.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\Test_Helper;
 
+use WPSEO_Options;
 use Yoast\WP\Test_Helper\WordPress_Plugins\WordPress_Plugin;
 
 /**
@@ -53,8 +54,8 @@ class WordPress_Plugin_Version {
 
 		$option_instance = false;
 		// Unhook option sanitization, otherwise the version cannot be changed.
-		if ( class_exists( '\WPSEO_Options' ) ) {
-			$option_instance = \WPSEO_Options::get_option_instance( $option_name );
+		if ( class_exists( WPSEO_Options::class ) ) {
+			$option_instance = WPSEO_Options::get_option_instance( $option_name );
 			remove_filter( 'sanitize_option_' . $option_name, [ $option_instance, 'validate' ] );
 		}
 

--- a/src/wordpress-plugins/local-seo.php
+++ b/src/wordpress-plugins/local-seo.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\WP\Test_Helper\WordPress_Plugins;
 
+use Yoast\WP\Test_Helper\WordPress_Plugins\WordPress_Plugin;
+
 /**
  * Class to represent Local SEO.
  */

--- a/src/wordpress-plugins/news-seo.php
+++ b/src/wordpress-plugins/news-seo.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\WP\Test_Helper\WordPress_Plugins;
 
+use Yoast\WP\Test_Helper\WordPress_Plugins\WordPress_Plugin;
+
 /**
  * Class to represent News SEO.
  */

--- a/src/wordpress-plugins/news-seo.php
+++ b/src/wordpress-plugins/news-seo.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\Test_Helper\WordPress_Plugins;
 
+use WPSEO_News;
 use Yoast\WP\Test_Helper\WordPress_Plugins\WordPress_Plugin;
 
 /**
@@ -80,6 +81,6 @@ class News_SEO implements WordPress_Plugin {
 	 * @return string The current version of the plugin.
 	 */
 	public function get_version_constant() {
-		return class_exists( '\WPSEO_News' ) ? \WPSEO_News::VERSION : 'not active';
+		return class_exists( WPSEO_News::class ) ? WPSEO_News::VERSION : 'not active';
 	}
 }

--- a/src/wordpress-plugins/video-seo.php
+++ b/src/wordpress-plugins/video-seo.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\WP\Test_Helper\WordPress_Plugins;
 
+use Yoast\WP\Test_Helper\WordPress_Plugins\WordPress_Plugin;
+
 /**
  * Class to represent Video SEO.
  */

--- a/src/wordpress-plugins/woocommerce-seo.php
+++ b/src/wordpress-plugins/woocommerce-seo.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\Test_Helper\WordPress_Plugins;
 
+use Yoast_WooCommerce_SEO;
 use Yoast\WP\Test_Helper\WordPress_Plugins\WordPress_Plugin;
 
 /**
@@ -80,6 +81,6 @@ class WooCommerce_SEO implements WordPress_Plugin {
 	 * @return string The current version of the plugin.
 	 */
 	public function get_version_constant() {
-		return class_exists( '\Yoast_WooCommerce_SEO' ) ? \Yoast_WooCommerce_SEO::VERSION : 'not active';
+		return class_exists( Yoast_WooCommerce_SEO::class ) ? Yoast_WooCommerce_SEO::VERSION : 'not active';
 	}
 }

--- a/src/wordpress-plugins/woocommerce-seo.php
+++ b/src/wordpress-plugins/woocommerce-seo.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\WP\Test_Helper\WordPress_Plugins;
 
+use Yoast\WP\Test_Helper\WordPress_Plugins\WordPress_Plugin;
+
 /**
  * Class to represent WooCommerce SEO.
  */

--- a/src/wordpress-plugins/yoast-seo-premium.php
+++ b/src/wordpress-plugins/yoast-seo-premium.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\Test_Helper\WordPress_Plugins;
 
 use WPSEO_Premium;
+use Yoast\WP\Test_Helper\WordPress_Plugins\WordPress_Plugin;
 
 /**
  * Class to represent Local SEO.

--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\Test_Helper\WordPress_Plugins;
 
 use WPSEO_Options;
+use Yoast\WP\Test_Helper\WordPress_Plugins\WordPress_Plugin;
 
 /**
  * Class to represent Yoast SEO.

--- a/src/xml-sitemaps.php
+++ b/src/xml-sitemaps.php
@@ -2,6 +2,10 @@
 
 namespace Yoast\WP\Test_Helper;
 
+use Yoast\WP\Test_Helper\Form_Presenter;
+use Yoast\WP\Test_Helper\Integration;
+use Yoast\WP\Test_Helper\Option;
+
 /**
  * Class to manage registering and rendering the admin page in WordPress.
  */


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Code consistency

## Relevant technical choices:

## QA: add missing import `use` statements for classes

Always be explicit about which classes are being used in a namespaced file, even when it's a class from within the same namespace.

## QA: import classes + use `::class`

Using `ClassName::class` (PHP 5.5+) translates to the Fully Qualified Class name as a string.

## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

This PR can be tested by following these steps:

* _N/A_ No functional changes.
