### PR TITLE
QA: use FQN function calls in namespaced files

### DIFF
--- a/src/admin-bar-panel.php
+++ b/src/admin-bar-panel.php
@@ -25,14 +25,14 @@ class Admin_Bar_Panel extends Debug_Bar_Panel {
 		echo '<div class="clear"></div>';
 		echo '<ul>';
 		foreach ( WPSEO_Options::get_option_names() as $option ) {
-			printf( '<li><a style="text-decoration: none !important;" href="#%1$s">%2$s</a></li>', esc_attr( $option ), esc_html( $option ) );
+			\printf( '<li><a style="text-decoration: none !important;" href="#%1$s">%2$s</a></li>', \esc_attr( $option ), \esc_html( $option ) );
 		}
 		echo '</ul>';
 		foreach ( WPSEO_Options::get_option_names() as $option ) {
-			echo '<h3 id="' . esc_attr( $option ) . '">Option: <span class="wpseo-debug">' . esc_html( $option ) . '</span></h3>';
+			echo '<h3 id="' . \esc_attr( $option ) . '">Option: <span class="wpseo-debug">' . \esc_html( $option ) . '</span></h3>';
 			echo '<pre>';
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export,WordPress.Security.EscapeOutput.OutputNotEscaped
-			echo var_export( get_option( $option ) );
+			echo \var_export( \get_option( $option ) );
 			echo '</pre>';
 		}
 	}

--- a/src/admin-debug-info.php
+++ b/src/admin-debug-info.php
@@ -34,9 +34,9 @@ class Admin_Debug_Info implements Integration {
 	 * @return void
 	 */
 	public function add_hooks() {
-		add_filter( 'debug_bar_panels', [ $this, 'add_debug_panel' ] );
+		\add_filter( 'debug_bar_panels', [ $this, 'add_debug_panel' ] );
 
-		add_action(
+		\add_action(
 			'admin_post_yoast_seo_debug_settings',
 			[ $this, 'handle_submit' ]
 		);
@@ -50,7 +50,7 @@ class Admin_Debug_Info implements Integration {
 	 * @return \Admin_Bar_Panel[] Panels array.
 	 */
 	public function add_debug_panel( $panels ) {
-		if ( $this->option->get( 'show_options_debug' ) === true && defined( 'WPSEO_VERSION' ) ) {
+		if ( $this->option->get( 'show_options_debug' ) === true && \defined( 'WPSEO_VERSION' ) ) {
 			$panels[] = new Admin_Bar_Panel();
 		}
 		return $panels;
@@ -76,10 +76,10 @@ class Admin_Debug_Info implements Integration {
 	 * @return void
 	 */
 	public function handle_submit() {
-		if ( check_admin_referer( 'yoast_seo_debug_settings' ) !== false ) {
+		if ( \check_admin_referer( 'yoast_seo_debug_settings' ) !== false ) {
 			$this->option->set( 'show_options_debug', isset( $_POST['show_options_debug'] ) );
 		}
 
-		wp_safe_redirect( self_admin_url( 'tools.php?page=' . apply_filters( 'Yoast\WP\Test_Helper\admin_page', '' ) ) );
+		\wp_safe_redirect( \self_admin_url( 'tools.php?page=' . \apply_filters( 'Yoast\WP\Test_Helper\admin_page', '' ) ) );
 	}
 }

--- a/src/admin-notifications.php
+++ b/src/admin-notifications.php
@@ -23,8 +23,8 @@ class Admin_Notifications implements Integration {
 	 * @return void
 	 */
 	public function add_hooks() {
-		add_action( 'Yoast\WP\Test_Helper\notification', [ $this, 'add_notification' ], 10, 2 );
-		add_action( 'Yoast\WP\Test_Helper\notifications', [ $this, 'display_notifications' ] );
+		\add_action( 'Yoast\WP\Test_Helper\notification', [ $this, 'add_notification' ], 10, 2 );
+		\add_action( 'Yoast\WP\Test_Helper\notifications', [ $this, 'display_notifications' ] );
 	}
 
 	/**
@@ -54,11 +54,11 @@ class Admin_Notifications implements Integration {
 
 		echo '<div style="margin: 15px 0 15px -15px;">';
 		foreach ( $notifications as $notification ) {
-			echo '<div class="notice notice-' . esc_attr( $notification->get_type() ) . '"><p>' . wp_kses_post( $notification->get_message() ) . '</p></div>';
+			echo '<div class="notice notice-' . \esc_attr( $notification->get_type() ) . '"><p>' . \wp_kses_post( $notification->get_message() ) . '</p></div>';
 		}
 		echo '</div>';
 
-		delete_user_meta( get_current_user_id(), $this->get_option_name() );
+		\delete_user_meta( \get_current_user_id(), $this->get_option_name() );
 	}
 
 	/**
@@ -67,8 +67,8 @@ class Admin_Notifications implements Integration {
 	 * @return \Yoast\WP\Test_Helper\Notification[] List of notifications.
 	 */
 	protected function get_notifications() {
-		$saved = get_user_meta( get_current_user_id(), $this->get_option_name(), true );
-		if ( ! is_array( $saved ) ) {
+		$saved = \get_user_meta( \get_current_user_id(), $this->get_option_name(), true );
+		if ( ! \is_array( $saved ) ) {
 			return [];
 		}
 
@@ -92,6 +92,6 @@ class Admin_Notifications implements Integration {
 	 * @return void
 	 */
 	protected function save_notifications( $notifications ) {
-		update_user_meta( get_current_user_id(), $this->get_option_name(), $notifications );
+		\update_user_meta( \get_current_user_id(), $this->get_option_name(), $notifications );
 	}
 }

--- a/src/admin-page.php
+++ b/src/admin-page.php
@@ -22,9 +22,9 @@ class Admin_Page implements Integration {
 	 * @return void
 	 */
 	public function add_hooks() {
-		add_action( 'admin_menu', [ $this, 'register_admin_menu' ] );
+		\add_action( 'admin_menu', [ $this, 'register_admin_menu' ] );
 
-		add_filter( 'Yoast\WP\Test_Helper\admin_page', [ $this, 'get_admin_page' ] );
+		\add_filter( 'Yoast\WP\Test_Helper\admin_page', [ $this, 'get_admin_page' ] );
 	}
 
 	/**
@@ -43,13 +43,13 @@ class Admin_Page implements Integration {
 	 */
 	public function add_assets() {
 		// CSS file.
-		wp_enqueue_style(
+		\wp_enqueue_style(
 			'yoast-test-admin-style',
-			plugin_dir_url( YOAST_TEST_HELPER_FILE ) . 'assets/css/admin.css',
+			\plugin_dir_url( YOAST_TEST_HELPER_FILE ) . 'assets/css/admin.css',
 			null,
 			YOAST_TEST_HELPER_VERSION
 		);
-		wp_enqueue_script( 'masonry' );
+		\wp_enqueue_script( 'masonry' );
 	}
 
 	/**
@@ -58,14 +58,14 @@ class Admin_Page implements Integration {
 	 * @return void
 	 */
 	public function register_admin_menu() {
-		$menu_item = add_management_page(
+		$menu_item = \add_management_page(
 			'Yoast Test',
 			'Yoast Test',
 			'manage_options',
-			sanitize_key( $this->get_admin_page() ),
+			\sanitize_key( $this->get_admin_page() ),
 			[ $this, 'show_admin_page' ]
 		);
-		add_action( 'admin_print_styles-' . $menu_item, [ $this, 'add_assets' ] );
+		\add_action( 'admin_print_styles-' . $menu_item, [ $this, 'add_assets' ] );
 	}
 
 	/**
@@ -87,12 +87,12 @@ class Admin_Page implements Integration {
 	public function show_admin_page() {
 		echo '<h1>Yoast Test Helper</h1>';
 
-		do_action( 'Yoast\WP\Test_Helper\notifications', $this );
+		\do_action( 'Yoast\WP\Test_Helper\notifications', $this );
 
 		echo '<div id="yoast_masonry">';
 		$this->masonry_script();
 
-		array_map(
+		\array_map(
 			static function( $block ) {
 				echo '<div class="wpseo_test_block">';
 				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/src/development-mode.php
+++ b/src/development-mode.php
@@ -34,10 +34,10 @@ class Development_Mode implements Integration {
 	 */
 	public function add_hooks() {
 		if ( $this->option->get( 'enable_development_mode' ) ) {
-			add_filter( 'yoast_seo_development_mode', '__return_true' );
+			\add_filter( 'yoast_seo_development_mode', '__return_true' );
 		}
 
-		add_action( 'admin_post_yoast_seo_test_development_mode', [ $this, 'handle_submit' ] );
+		\add_action( 'admin_post_yoast_seo_test_development_mode', [ $this, 'handle_submit' ] );
 	}
 
 	/**
@@ -61,11 +61,11 @@ class Development_Mode implements Integration {
 	 * @return void
 	 */
 	public function handle_submit() {
-		if ( check_admin_referer( 'yoast_seo_test_development_mode' ) !== false ) {
+		if ( \check_admin_referer( 'yoast_seo_test_development_mode' ) !== false ) {
 			$this->set_bool_option( 'enable_development_mode' );
 		}
 
-		wp_safe_redirect( self_admin_url( 'tools.php?page=' . apply_filters( 'Yoast\WP\Test_Helper\admin_page', '' ) ) );
+		\wp_safe_redirect( \self_admin_url( 'tools.php?page=' . \apply_filters( 'Yoast\WP\Test_Helper\admin_page', '' ) ) );
 	}
 
 	/**

--- a/src/domain-dropdown.php
+++ b/src/domain-dropdown.php
@@ -33,14 +33,14 @@ class Domain_Dropdown implements Integration {
 	 * @return void
 	 */
 	public function add_hooks() {
-		add_action( 'admin_post_yoast_seo_domain_dropdown', [ $this, 'handle_submit' ] );
+		\add_action( 'admin_post_yoast_seo_domain_dropdown', [ $this, 'handle_submit' ] );
 
 		$domain = $this->option->get( 'myyoast_test_domain' );
 		if ( ! empty( $domain ) && $domain !== 'https://my.yoast.com' ) {
-			add_action( 'requests-requests.before_request', [ $this, 'modify_myyoast_request' ], 10, 2 );
+			\add_action( 'requests-requests.before_request', [ $this, 'modify_myyoast_request' ], 10, 2 );
 		}
 		else {
-			remove_action( 'requests-requests.before_request', [ $this, 'modify_myyoast_request' ], 10 );
+			\remove_action( 'requests-requests.before_request', [ $this, 'modify_myyoast_request' ], 10 );
 		}
 	}
 
@@ -74,11 +74,11 @@ class Domain_Dropdown implements Integration {
 	 * @return void
 	 */
 	public function handle_submit() {
-		if ( check_admin_referer( 'yoast_seo_domain_dropdown' ) !== false ) {
-			$this->option->set( 'myyoast_test_domain', filter_input( INPUT_POST, 'myyoast_test_domain', FILTER_SANITIZE_STRING ) );
+		if ( \check_admin_referer( 'yoast_seo_domain_dropdown' ) !== false ) {
+			$this->option->set( 'myyoast_test_domain', \filter_input( INPUT_POST, 'myyoast_test_domain', FILTER_SANITIZE_STRING ) );
 		}
 
-		wp_safe_redirect( self_admin_url( 'tools.php?page=' . apply_filters( 'Yoast\WP\Test_Helper\admin_page', '' ) ) );
+		\wp_safe_redirect( \self_admin_url( 'tools.php?page=' . \apply_filters( 'Yoast\WP\Test_Helper\admin_page', '' ) ) );
 	}
 
 	/**
@@ -102,9 +102,9 @@ class Domain_Dropdown implements Integration {
 
 		if ( $request_parameters['host'] ) {
 			$headers['Host'] = $request_parameters['host'];
-			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			if ( \defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-				error_log( sprintf( "SANDBOXING via '%s': '%s'", $domain, $original_url ) );
+				\error_log( \sprintf( "SANDBOXING via '%s': '%s'", $domain, $original_url ) );
 			}
 		}
 	}
@@ -119,14 +119,14 @@ class Domain_Dropdown implements Integration {
 	 */
 	private function replace_domain( $domain, $url, $headers ) {
 		$host     = '';
-		$url_host = wp_parse_url( $url, PHP_URL_HOST );
+		$url_host = \wp_parse_url( $url, PHP_URL_HOST );
 
 		if ( $url_host === 'my.yoast.com' ) {
 			$host = isset( $headers['Host'] ) ? $headers['Host'] : $url_host;
-			$url  = str_replace( 'https://' . $url_host, $domain, $url );
+			$url  = \str_replace( 'https://' . $url_host, $domain, $url );
 		}
 
-		return compact( 'url', 'host' );
+		return \compact( 'url', 'host' );
 	}
 }
 

--- a/src/feature-toggler.php
+++ b/src/feature-toggler.php
@@ -42,9 +42,9 @@ class Feature_Toggler implements Integration {
 	 * @return void
 	 */
 	public function add_hooks() {
-		add_action( 'wpseo_enable_feature', [ $this, 'enable_features' ] );
+		\add_action( 'wpseo_enable_feature', [ $this, 'enable_features' ] );
 
-		add_action(
+		\add_action(
 			'admin_post_yoast_seo_feature_toggler',
 			[ $this, 'handle_submit' ]
 		);
@@ -76,14 +76,14 @@ class Feature_Toggler implements Integration {
 	 * @return void
 	 */
 	public function handle_submit() {
-		if ( check_admin_referer( 'yoast_seo_feature_toggler' ) !== false ) {
+		if ( \check_admin_referer( 'yoast_seo_feature_toggler' ) !== false ) {
 			foreach ( $this->features as $feature => $label ) {
 				$key = 'feature_toggle_' . $feature;
 				$this->option->set( $key, isset( $_POST[ $key ] ) );
 			}
 		}
 
-		wp_safe_redirect( self_admin_url( 'tools.php?page=' . apply_filters( 'Yoast\WP\Test_Helper\admin_page', '' ) ) );
+		\wp_safe_redirect( \self_admin_url( 'tools.php?page=' . \apply_filters( 'Yoast\WP\Test_Helper\admin_page', '' ) ) );
 	}
 
 	/**

--- a/src/form-presenter.php
+++ b/src/form-presenter.php
@@ -18,10 +18,10 @@ class Form_Presenter {
 	 * @return string The HTML to render the form.
 	 */
 	public static function get_html( $title, $nonce_field, $fields, $submit = true ) {
-		$field   = esc_attr( $nonce_field );
-		$output  = '<h2>' . esc_html( $title ) . '</h2>';
-		$output .= '<form action="' . esc_url( admin_url( 'admin-post.php' ) ) . '" method="POST">';
-		$output .= str_replace( 'id="_wpnonce"', '', wp_nonce_field( $nonce_field, '_wpnonce', true, false ) );
+		$field   = \esc_attr( $nonce_field );
+		$output  = '<h2>' . \esc_html( $title ) . '</h2>';
+		$output .= '<form action="' . \esc_url( \admin_url( 'admin-post.php' ) ) . '" method="POST">';
+		$output .= \str_replace( 'id="_wpnonce"', '', \wp_nonce_field( $nonce_field, '_wpnonce', true, false ) );
 		$output .= '<input type="hidden" name="action" value="' . $field . '">';
 
 		$output .= $fields;
@@ -45,9 +45,9 @@ class Form_Presenter {
 	 * @return string The checkbox & label HTML.
 	 */
 	public static function create_checkbox( $option, $label, $checked = false ) {
-		$checked_html = checked( $checked, true, false );
-		$output       = sprintf( '<input type="checkbox" ' . $checked_html . ' name="%1$s" id="%1$s"/>', $option );
-		$output      .= sprintf( '<label for="%1$s">%2$s</label><br/>', $option, $label );
+		$checked_html = \checked( $checked, true, false );
+		$output       = \sprintf( '<input type="checkbox" ' . $checked_html . ' name="%1$s" id="%1$s"/>', $option );
+		$output      .= \sprintf( '<label for="%1$s">%2$s</label><br/>', $option, $label );
 
 		return $output;
 	}
@@ -63,11 +63,11 @@ class Form_Presenter {
 	 * @return string The select & label HTML.
 	 */
 	public static function create_select( $option, $label, $options, $selected = false ) {
-		$output  = sprintf( '<label for="%1$s">%2$s</label>', $option, $label );
-		$output .= sprintf( '<select name="%1$s" id="%1$s">', $option );
+		$output  = \sprintf( '<label for="%1$s">%2$s</label>', $option, $label );
+		$output .= \sprintf( '<select name="%1$s" id="%1$s">', $option );
 		foreach ( $options as $value => $option_label ) {
-			$selected_html = selected( $selected === $value, true, false );
-			$output       .= sprintf( '<option ' . $selected_html . ' value="%1$s">%2$s</option>', $value, $option_label );
+			$selected_html = \selected( $selected === $value, true, false );
+			$output       .= \sprintf( '<option ' . $selected_html . ' value="%1$s">%2$s</option>', $value, $option_label );
 		}
 		$output .= '</select><br/>';
 

--- a/src/inline-script.php
+++ b/src/inline-script.php
@@ -33,8 +33,8 @@ class Inline_Script implements Integration {
 	 * @return void
 	 */
 	public function add_hooks() {
-		add_action( 'admin_enqueue_scripts', [ $this, 'add_inline_script' ] );
-		add_action( 'admin_post_yoast_seo_test_inline_script', [ $this, 'handle_submit' ] );
+		\add_action( 'admin_enqueue_scripts', [ $this, 'add_inline_script' ] );
+		\add_action( 'admin_post_yoast_seo_test_inline_script', [ $this, 'handle_submit' ] );
 	}
 
 	/**
@@ -44,7 +44,7 @@ class Inline_Script implements Integration {
 		if ( $this->option->get( 'add_inline_script' ) !== true ) {
 			return;
 		}
-		wp_add_inline_script(
+		\wp_add_inline_script(
 			$this->option->get( 'inline_script_handle' ),
 			$this->option->get( 'inline_script' )
 		);
@@ -69,7 +69,7 @@ class Inline_Script implements Integration {
 		$value = $this->option->get( 'inline_script' );
 
 		$output .= '<label for="inline_script">Script (do not include <code>&lt;script&gt;</code> tags):</label><br/>';
-		$output .= '<textarea style="width: 100%; min-height: 300px; font-family: monospace;" name="inline_script" id="inline_script">' . esc_html( $value ) . '</textarea><br/>';
+		$output .= '<textarea style="width: 100%; min-height: 300px; font-family: monospace;" name="inline_script" id="inline_script">' . \esc_html( $value ) . '</textarea><br/>';
 
 		return Form_Presenter::get_html( 'Inline script', 'yoast_seo_test_inline_script', $output );
 	}
@@ -80,13 +80,13 @@ class Inline_Script implements Integration {
 	 * @return void
 	 */
 	public function handle_submit() {
-		if ( check_admin_referer( 'yoast_seo_test_inline_script' ) !== false ) {
+		if ( \check_admin_referer( 'yoast_seo_test_inline_script' ) !== false ) {
 			$this->option->set( 'add_inline_script', isset( $_POST['add_inline_script'] ) );
-			$this->option->set( 'inline_script_handle', filter_input( INPUT_POST, 'inline_script_handle', FILTER_SANITIZE_STRING ) );
-			$this->option->set( 'inline_script', filter_input( INPUT_POST, 'inline_script', FILTER_SANITIZE_STRING ) );
+			$this->option->set( 'inline_script_handle', \filter_input( INPUT_POST, 'inline_script_handle', FILTER_SANITIZE_STRING ) );
+			$this->option->set( 'inline_script', \filter_input( INPUT_POST, 'inline_script', FILTER_SANITIZE_STRING ) );
 		}
 
-		wp_safe_redirect( self_admin_url( 'tools.php?page=' . apply_filters( 'Yoast\WP\Test_Helper\admin_page', '' ) ) );
+		\wp_safe_redirect( \self_admin_url( 'tools.php?page=' . \apply_filters( 'Yoast\WP\Test_Helper\admin_page', '' ) ) );
 	}
 
 	/**
@@ -98,13 +98,13 @@ class Inline_Script implements Integration {
 	 */
 	private function select_script( $value ) {
 		$output  = '<select name="inline_script_handle" id="inline_script_handle">';
-		$scripts = wp_scripts();
-		foreach ( array_keys( $scripts->registered ) as $script ) {
+		$scripts = \wp_scripts();
+		foreach ( \array_keys( $scripts->registered ) as $script ) {
 			$sel = '';
 			if ( $value === $script ) {
 				$sel = 'selected';
 			}
-			$output .= '<option value="' . esc_attr( $script ) . '" ' . $sel . '>' . esc_html( $script ) . '</option>';
+			$output .= '<option value="' . \esc_attr( $script ) . '" ' . $sel . '>' . \esc_html( $script ) . '</option>';
 		}
 		$output .= '</select>';
 

--- a/src/option.php
+++ b/src/option.php
@@ -62,7 +62,7 @@ class Option {
 	 * @return array The Test Helper options.
 	 */
 	private function get_option() {
-		return get_option( $this->option_name );
+		return \get_option( $this->option_name );
 	}
 
 	/**
@@ -71,6 +71,6 @@ class Option {
 	 * @return bool False if value was not updated and true if value was updated.
 	 */
 	private function save_options() {
-		return update_option( $this->option_name, $this->options, true );
+		return \update_option( $this->option_name, $this->options, true );
 	}
 }

--- a/src/plugin-toggler.php
+++ b/src/plugin-toggler.php
@@ -48,9 +48,9 @@ class Plugin_Toggler implements Integration {
 	 * @return void
 	 */
 	public function add_hooks() {
-		add_action( 'plugins_loaded', [ $this, 'init' ] );
+		\add_action( 'plugins_loaded', [ $this, 'init' ] );
 
-		add_action(
+		\add_action(
 			'admin_post_yoast_seo_plugin_toggler',
 			[ $this, 'handle_submit' ]
 		);
@@ -75,14 +75,14 @@ class Plugin_Toggler implements Integration {
 
 		// Load WordPress core plugin.php when needed.
 		if (
-			! function_exists( 'is_plugin_active' ) ||
-			! function_exists( 'get_plugins' )
+			! \function_exists( 'is_plugin_active' ) ||
+			! \function_exists( 'get_plugins' )
 		) {
 			include_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 
 		// Apply filters to adapt the $this->grouped_name_filter property.
-		$this->grouped_name_filter = apply_filters( 'Yoast\WP\Test_Helper\plugin_toggler_filter', $this->grouped_name_filter );
+		$this->grouped_name_filter = \apply_filters( 'Yoast\WP\Test_Helper\plugin_toggler_filter', $this->grouped_name_filter );
 
 		$this->init_plugin_groups();
 
@@ -96,7 +96,7 @@ class Plugin_Toggler implements Integration {
 	 * @return void
 	 */
 	public function add_toggle() {
-		$nonce = wp_create_nonce( 'yoast-plugin-toggle' );
+		$nonce = \wp_create_nonce( 'yoast-plugin-toggle' );
 
 		/** \WP_Admin_Bar $wp_admin_bar */
 		global $wp_admin_bar;
@@ -104,15 +104,15 @@ class Plugin_Toggler implements Integration {
 		// Add a menu for each group.
 		foreach ( $this->plugin_groups as $group => $plugins ) {
 			$active_plugin = $this->get_active_plugin( $group );
-			$menu_id       = 'wpseo-plugin-toggler-' . sanitize_title( $group );
+			$menu_id       = 'wpseo-plugin-toggler-' . \sanitize_title( $group );
 			$menu_title    = $active_plugin;
 
 			// Menu title fallback: active plugin > group > first plugin.
 			if ( $menu_title === '' ) {
 				$menu_title = $group;
 				if ( $menu_title === '' ) {
-					reset( $plugins );
-					$menu_title = key( $plugins );
+					\reset( $plugins );
+					$menu_title = \key( $plugins );
 				}
 			}
 
@@ -134,11 +134,11 @@ class Plugin_Toggler implements Integration {
 				$wp_admin_bar->add_node(
 					[
 						'parent' => $menu_id,
-						'id'     => 'wpseo-plugin-toggle-' . sanitize_title( $plugin ),
+						'id'     => 'wpseo-plugin-toggle-' . \sanitize_title( $plugin ),
 						'title'  => 'Switch to ' . $plugin,
 						'href'   => '#',
 						'meta'   => [
-							'onclick' => sprintf(
+							'onclick' => \sprintf(
 								'Yoast_Plugin_Toggler.toggle_plugin( "%1$s", "%2$s", "%3$s" )',
 								$group,
 								$plugin,
@@ -158,9 +158,9 @@ class Plugin_Toggler implements Integration {
 	 */
 	public function add_assets() {
 		// JS file.
-		wp_enqueue_script(
+		\wp_enqueue_script(
 			'yoast-toggle-script',
-			plugin_dir_url( YOAST_TEST_HELPER_FILE ) . 'assets/js/yoast-toggle.js',
+			\plugin_dir_url( YOAST_TEST_HELPER_FILE ) . 'assets/js/yoast-toggle.js',
 			[],
 			YOAST_TEST_HELPER_VERSION,
 			true
@@ -181,8 +181,8 @@ class Plugin_Toggler implements Integration {
 
 		// If nonce is valid.
 		if ( $this->verify_nonce() ) {
-			$group  = filter_input( INPUT_GET, 'group' );
-			$plugin = filter_input( INPUT_GET, 'plugin' );
+			$group  = \filter_input( INPUT_GET, 'group' );
+			$plugin = \filter_input( INPUT_GET, 'plugin' );
 
 			// First deactivate the current plugin.
 			$this->deactivate_plugin_group( $group );
@@ -222,11 +222,11 @@ class Plugin_Toggler implements Integration {
 	 * @return void
 	 */
 	public function handle_submit() {
-		if ( check_admin_referer( 'yoast_seo_plugin_toggler' ) !== false ) {
+		if ( \check_admin_referer( 'yoast_seo_plugin_toggler' ) !== false ) {
 			$this->option->set( 'plugin_toggler', isset( $_POST['plugin_toggler'] ) );
 		}
 
-		wp_safe_redirect( self_admin_url( 'tools.php?page=' . apply_filters( 'Yoast\WP\Test_Helper\admin_page', '' ) ) );
+		\wp_safe_redirect( \self_admin_url( 'tools.php?page=' . \apply_filters( 'Yoast\WP\Test_Helper\admin_page', '' ) ) );
 	}
 
 	/**
@@ -237,7 +237,7 @@ class Plugin_Toggler implements Integration {
 	 * @return bool True if the rights are present.
 	 */
 	private function has_rights() {
-		return ( is_admin() && current_user_can( 'activate_plugins' ) );
+		return ( \is_admin() && \current_user_can( 'activate_plugins' ) );
 	}
 
 	/**
@@ -263,7 +263,7 @@ class Plugin_Toggler implements Integration {
 	 */
 	private function get_plugin_groups() {
 		// Use WordPress to get all the plugins with their data.
-		$plugins       = get_plugins();
+		$plugins       = \get_plugins();
 		$plugin_groups = [];
 
 		foreach ( $plugins as $file => $data ) {
@@ -296,10 +296,10 @@ class Plugin_Toggler implements Integration {
 	private function get_group_from_plugin_name( $plugin_name ) {
 		$matches = [];
 
-		if ( preg_match( $this->grouped_name_filter, $plugin_name, $matches ) ) {
+		if ( \preg_match( $this->grouped_name_filter, $plugin_name, $matches ) ) {
 			foreach ( $matches as $match ) {
 				if ( $match !== '' ) {
-					return trim( $match );
+					return \trim( $match );
 				}
 			}
 		}
@@ -320,17 +320,17 @@ class Plugin_Toggler implements Integration {
 
 		foreach ( $plugin_groups as $group => $plugins ) {
 			foreach ( $plugins as $plugin => $plugin_path ) {
-				$full_plugin_path = ABSPATH . 'wp-content/plugins/' . plugin_basename( $plugin_path );
+				$full_plugin_path = ABSPATH . 'wp-content/plugins/' . \plugin_basename( $plugin_path );
 
 				// Add the plugin to the group if it exists.
-				if ( file_exists( $full_plugin_path ) ) {
+				if ( \file_exists( $full_plugin_path ) ) {
 					$installed[ $group ][ $plugin ] = $plugin_path;
 				}
 			}
 
 			if ( $prune ) {
 				// Remove the group entirely if there are less than 2 plugins in it.
-				if ( count( $installed[ $group ] ) < 2 ) {
+				if ( \count( $installed[ $group ] ) < 2 ) {
 					unset( $installed[ $group ] );
 				}
 			}
@@ -347,13 +347,13 @@ class Plugin_Toggler implements Integration {
 	 * @return string The plugin name or an empty string.
 	 */
 	private function get_active_plugin( $group ) {
-		if ( ! array_key_exists( $group, $this->plugin_groups ) ) {
+		if ( ! \array_key_exists( $group, $this->plugin_groups ) ) {
 			return '';
 		}
 
 		$plugins = $this->plugin_groups[ $group ];
 		foreach ( $plugins as $plugin => $plugin_path ) {
-			if ( is_plugin_active( $plugin_path ) ) {
+			if ( \is_plugin_active( $plugin_path ) ) {
 				return $plugin;
 			}
 		}
@@ -368,12 +368,12 @@ class Plugin_Toggler implements Integration {
 	 */
 	private function add_additional_hooks() {
 		// Setting AJAX-request to toggle the plugin.
-		add_action( 'wp_ajax_toggle_plugin', [ $this, 'ajax_toggle_plugin' ] );
+		\add_action( 'wp_ajax_toggle_plugin', [ $this, 'ajax_toggle_plugin' ] );
 
 		// Adding assets.
-		add_action( 'admin_init', [ $this, 'add_assets' ] );
+		\add_action( 'admin_init', [ $this, 'add_assets' ] );
 
-		add_action( 'admin_bar_menu', [ $this, 'add_toggle' ], 100 );
+		\add_action( 'admin_bar_menu', [ $this, 'add_toggle' ], 100 );
 	}
 
 	/**
@@ -385,15 +385,15 @@ class Plugin_Toggler implements Integration {
 	 * @return void
 	 */
 	private function activate_plugin( $group, $plugin ) {
-		if ( ! array_key_exists( $group, $this->plugin_groups ) ) {
+		if ( ! \array_key_exists( $group, $this->plugin_groups ) ) {
 			return;
 		}
-		if ( ! array_key_exists( $plugin, $this->plugin_groups[ $group ] ) ) {
+		if ( ! \array_key_exists( $plugin, $this->plugin_groups[ $group ] ) ) {
 			return;
 		}
 
 		$plugin_path = $this->plugin_groups[ $group ][ $plugin ];
-		activate_plugin( plugin_basename( $plugin_path ), null, false, true );
+		\activate_plugin( \plugin_basename( $plugin_path ), null, false, true );
 	}
 
 	/**
@@ -406,14 +406,14 @@ class Plugin_Toggler implements Integration {
 	 * @return void
 	 */
 	private function deactivate_plugin_group( $group ) {
-		if ( ! array_key_exists( $group, $this->plugin_groups ) ) {
+		if ( ! \array_key_exists( $group, $this->plugin_groups ) ) {
 			return;
 		}
 
 		$plugins = $this->plugin_groups[ $group ];
 		foreach ( $plugins as $plugin_path ) {
-			if ( is_plugin_active( $plugin_path ) ) {
-				deactivate_plugins( plugin_basename( $plugin_path ), true );
+			if ( \is_plugin_active( $plugin_path ) ) {
+				\deactivate_plugins( \plugin_basename( $plugin_path ), true );
 			}
 		}
 	}
@@ -425,10 +425,10 @@ class Plugin_Toggler implements Integration {
 	 */
 	private function verify_nonce() {
 		// Get the nonce value.
-		$ajax_nonce = filter_input( INPUT_GET, 'ajax_nonce' );
+		$ajax_nonce = \filter_input( INPUT_GET, 'ajax_nonce' );
 
 		// If nonce is valid return true.
-		if ( wp_verify_nonce( $ajax_nonce, 'yoast-plugin-toggle' ) ) {
+		if ( \wp_verify_nonce( $ajax_nonce, 'yoast-plugin-toggle' ) ) {
 			return true;
 		}
 	}
@@ -443,7 +443,7 @@ class Plugin_Toggler implements Integration {
 		$plugin_groups = $this->get_plugin_groups();
 
 		// Apply filters to extend the $this->plugin_groups property.
-		$plugin_groups = (array) apply_filters( 'Yoast\WP\Test_Helper\plugin_toggle_extend', $plugin_groups );
+		$plugin_groups = (array) \apply_filters( 'Yoast\WP\Test_Helper\plugin_toggle_extend', $plugin_groups );
 
 		// Check the plugins after the filter.
 		$this->plugin_groups = $this->check_plugins( $plugin_groups );

--- a/src/plugin-version-control.php
+++ b/src/plugin-version-control.php
@@ -58,7 +58,7 @@ class Plugin_Version_Control implements Integration {
 	 * @return void
 	 */
 	public function add_hooks() {
-		add_action( 'admin_post_yoast_version_control', [ $this, 'handle_submit' ] );
+		\add_action( 'admin_post_yoast_version_control', [ $this, 'handle_submit' ] );
 	}
 
 	/**
@@ -90,14 +90,14 @@ class Plugin_Version_Control implements Integration {
 	 * @return void
 	 */
 	public function handle_submit() {
-		if ( ! $this->load_history() && check_admin_referer( 'yoast_version_control' ) !== false ) {
+		if ( ! $this->load_history() && \check_admin_referer( 'yoast_version_control' ) !== false ) {
 			foreach ( $this->plugins as $plugin ) {
 				// phpcs:ignore WordPress.Security.ValidatedSanitizedInput
 				$this->update_plugin_version( $plugin, $_POST[ $plugin->get_identifier() ] );
 			}
 		}
 
-		wp_safe_redirect( self_admin_url( 'tools.php?page=' . apply_filters( 'Yoast\WP\Test_Helper\admin_page', '' ) ) );
+		\wp_safe_redirect( \self_admin_url( 'tools.php?page=' . \apply_filters( 'Yoast\WP\Test_Helper\admin_page', '' ) ) );
 	}
 
 	/**
@@ -108,14 +108,14 @@ class Plugin_Version_Control implements Integration {
 	 */
 	protected function update_plugin_version( WordPress_Plugin $plugin, $version ) {
 		if ( $this->plugin_version->update_version( $plugin, $version ) ) {
-			do_action(
+			\do_action(
 				'Yoast\WP\Test_Helper\notification',
 				new Notification( $plugin->get_name() . ' version was set to ' . $version, 'success' )
 			);
 		}
 
 		if ( $this->plugin_options->save_options( $plugin ) ) {
-			do_action(
+			\do_action(
 				'Yoast\WP\Test_Helper\notification',
 				new Notification( $plugin->get_name() . ' options were saved.', 'success' )
 			);
@@ -130,12 +130,12 @@ class Plugin_Version_Control implements Integration {
 	 * @return string The plugin option.
 	 */
 	protected function get_plugin_option( WordPress_Plugin $plugin ) {
-		return sprintf(
+		return \sprintf(
 			'<tr><td>%s:</td><td><input type="text" name="%s" value="%s" maxlength="9" size="10"></td><td>(%s)</td><td>%s</td></tr>',
-			esc_html( $plugin->get_name() ),
-			esc_attr( $plugin->get_identifier() ),
-			esc_attr( $this->plugin_version->get_version( $plugin ) ),
-			esc_html( $plugin->get_version_constant() ),
+			\esc_html( $plugin->get_name() ),
+			\esc_attr( $plugin->get_identifier() ),
+			\esc_attr( $this->plugin_version->get_version( $plugin ) ),
+			\esc_html( $plugin->get_version_constant() ),
 			$this->get_option_history_select( $plugin )
 		);
 	}
@@ -149,14 +149,14 @@ class Plugin_Version_Control implements Integration {
 	 */
 	protected function get_option_history_select( WordPress_Plugin $plugin ) {
 		$history = $this->plugin_options->get_saved_options( $plugin );
-		$history = array_reverse( $history, true );
+		$history = \array_reverse( $history, true );
 
-		return sprintf(
+		return \sprintf(
 			'<select name="%s"><option value=""></option>%s</select>',
-			esc_attr( $plugin->get_identifier() . '-history' ),
-			implode(
+			\esc_attr( $plugin->get_identifier() . '-history' ),
+			\implode(
 				'',
-				array_map(
+				\array_map(
 					static function ( $timestamp, $item ) use ( $plugin ) {
 						$version_option = $plugin->get_version_option_name();
 						$version_key    = $plugin->get_version_key();
@@ -170,14 +170,14 @@ class Plugin_Version_Control implements Integration {
 							$version = $item[ $version_option ];
 						}
 
-						return sprintf(
+						return \sprintf(
 							'<option value="%s">(%s) %s</option>',
-							esc_attr( $timestamp ),
-							esc_html( $version ),
-							esc_html( gmdate( 'Y-m-d H:i:s', $timestamp ) )
+							\esc_attr( $timestamp ),
+							\esc_html( $version ),
+							\esc_html( \gmdate( 'Y-m-d H:i:s', $timestamp ) )
 						);
 					},
-					array_keys( $history ),
+					\array_keys( $history ),
 					$history
 				)
 			)
@@ -190,7 +190,7 @@ class Plugin_Version_Control implements Integration {
 	 * @return bool
 	 */
 	protected function load_history() {
-		if ( check_admin_referer( 'yoast_version_control' ) === false ) {
+		if ( \check_admin_referer( 'yoast_version_control' ) === false ) {
 			return false;
 		}
 
@@ -200,20 +200,20 @@ class Plugin_Version_Control implements Integration {
 			$timestamp = $_POST[ $plugin->get_identifier() . '-history' ];
 			if ( ! empty( $timestamp ) ) {
 				$notification = new Notification(
-					'Options from ' . gmdate( 'Y-m-d H:i:s', $timestamp )
+					'Options from ' . \gmdate( 'Y-m-d H:i:s', $timestamp )
 					. ' for ' . $plugin->get_name() . ' have <strong>not</strong> been restored.',
 					'error'
 				);
 
 				if ( $this->plugin_options->restore_options( $plugin, $timestamp ) ) {
 					$notification = new Notification(
-						'Options from ' . gmdate( 'Y-m-d H:i:s', $timestamp )
+						'Options from ' . \gmdate( 'Y-m-d H:i:s', $timestamp )
 						. ' for ' . $plugin->get_name() . ' have been restored.',
 						'success'
 					);
 				}
 
-				do_action( 'Yoast\WP\Test_Helper\notification', $notification );
+				\do_action( 'Yoast\WP\Test_Helper\notification', $notification );
 
 				return true;
 			}

--- a/src/plugin.php
+++ b/src/plugin.php
@@ -46,7 +46,7 @@ class Plugin implements Integration {
 	public function __construct() {
 		$this->load_integrations();
 
-		add_action( 'Yoast\WP\Test_Helper\notifications', [ $this, 'admin_page_blocks' ] );
+		\add_action( 'Yoast\WP\Test_Helper\notifications', [ $this, 'admin_page_blocks' ] );
 	}
 
 	/**
@@ -55,7 +55,7 @@ class Plugin implements Integration {
 	 * @return void
 	 */
 	public function add_hooks() {
-		array_map(
+		\array_map(
 			static function ( Integration $integration ) {
 				$integration->add_hooks();
 			},
@@ -70,7 +70,7 @@ class Plugin implements Integration {
 	 */
 	public function admin_page_blocks( Admin_Page $admin_page ) {
 		foreach ( $this->integrations as $integration ) {
-			if ( method_exists( $integration, 'get_controls' ) ) {
+			if ( \method_exists( $integration, 'get_controls' ) ) {
 				$admin_page->add_admin_page_block( [ $integration, 'get_controls' ] );
 			}
 		}

--- a/src/post-types.php
+++ b/src/post-types.php
@@ -80,12 +80,12 @@ class Post_Types implements Integration {
 	 */
 	public function add_hooks() {
 		if ( $this->option->get( 'enable_post_types' ) === true ) {
-			add_action( 'init', [ $this, 'register_post_types' ] );
+			\add_action( 'init', [ $this, 'register_post_types' ] );
 		}
 
-		add_action( 'admin_post_yoast_seo_test_post_types', [ $this, 'handle_submit' ] );
-		add_filter( 'gutenberg_can_edit_post_type', [ $this, 'disable_gutenberg' ], 10, 2 );
-		add_filter( 'use_block_editor_for_post_type', [ $this, 'disable_gutenberg' ], 10, 2 );
+		\add_action( 'admin_post_yoast_seo_test_post_types', [ $this, 'handle_submit' ] );
+		\add_filter( 'gutenberg_can_edit_post_type', [ $this, 'disable_gutenberg' ], 10, 2 );
+		\add_filter( 'use_block_editor_for_post_type', [ $this, 'disable_gutenberg' ], 10, 2 );
 	}
 
 	/**
@@ -113,8 +113,8 @@ class Post_Types implements Integration {
 	 * @return void
 	 */
 	public function register_post_types() {
-		register_post_type( 'book', $this->book_args );
-		register_post_type( 'movie', $this->movie_args );
+		\register_post_type( 'book', $this->book_args );
+		\register_post_type( 'movie', $this->movie_args );
 	}
 
 	/**
@@ -150,23 +150,23 @@ class Post_Types implements Integration {
 	 * @return void
 	 */
 	public function handle_submit() {
-		if ( check_admin_referer( 'yoast_seo_test_post_types' ) !== false ) {
+		if ( \check_admin_referer( 'yoast_seo_test_post_types' ) !== false ) {
 			$this->set_bool_option( 'enable_post_types' );
 			$this->set_bool_option( 'enable_gutenberg_books' );
 			$this->set_bool_option( 'enable_gutenberg_videos' );
 		}
 
 		// If we've now enabled the post types, make sure they work.
-		if ( $this->option->get( 'enable_post_types' ) && ! post_type_exists( 'book' ) ) {
+		if ( $this->option->get( 'enable_post_types' ) && ! \post_type_exists( 'book' ) ) {
 			$this->register_post_types();
 
 			// Hook this to shutdown so we're certain all the required post types have been registered.
-			add_action( 'shutdown', [ $this, 'flush_rewrite_rules' ] );
+			\add_action( 'shutdown', [ $this, 'flush_rewrite_rules' ] );
 		}
 
-		wp_safe_redirect(
-			self_admin_url(
-				'tools.php?page=' . apply_filters( 'Yoast\WP\Test_Helper\admin_page', '' )
+		\wp_safe_redirect(
+			\self_admin_url(
+				'tools.php?page=' . \apply_filters( 'Yoast\WP\Test_Helper\admin_page', '' )
 			)
 		);
 	}

--- a/src/schema.php
+++ b/src/schema.php
@@ -33,30 +33,30 @@ class Schema implements Integration {
 	 */
 	public function add_hooks() {
 		if ( $this->option->get( 'replace_schema_domain' ) === true ) {
-			add_filter( 'wpseo_debug_json_data', [ $this, 'replace_domain' ] );
+			\add_filter( 'wpseo_debug_json_data', [ $this, 'replace_domain' ] );
 		}
 
 		switch ( $this->option->get( 'is_needed_breadcrumb' ) ) {
 			case 'show':
 			case 'hide':
-				add_filter( 'wpseo_schema_needs_breadcrumb', [ $this, 'filter_is_needed_breadcrumb' ] );
+				\add_filter( 'wpseo_schema_needs_breadcrumb', [ $this, 'filter_is_needed_breadcrumb' ] );
 				break;
 			default:
-				remove_filter( 'wpseo_schema_needs_breadcrumb', [ $this, 'filter_is_needed_breadcrumb' ] );
+				\remove_filter( 'wpseo_schema_needs_breadcrumb', [ $this, 'filter_is_needed_breadcrumb' ] );
 				break;
 		}
 
 		switch ( $this->option->get( 'is_needed_webpage' ) ) {
 			case 'show':
 			case 'hide':
-				add_filter( 'wpseo_schema_needs_webpage', [ $this, 'filter_is_needed_webpage' ] );
+				\add_filter( 'wpseo_schema_needs_webpage', [ $this, 'filter_is_needed_webpage' ] );
 				break;
 			default:
-				remove_filter( 'wpseo_schema_needs_webpage', [ $this, 'filter_is_needed_webpage' ] );
+				\remove_filter( 'wpseo_schema_needs_webpage', [ $this, 'filter_is_needed_webpage' ] );
 				break;
 		}
 
-		add_action( 'admin_post_yoast_seo_test_schema', [ $this, 'handle_submit' ] );
+		\add_action( 'admin_post_yoast_seo_test_schema', [ $this, 'handle_submit' ] );
 	}
 
 	/**
@@ -100,17 +100,17 @@ class Schema implements Integration {
 	 * @return void
 	 */
 	public function handle_submit() {
-		if ( check_admin_referer( 'yoast_seo_test_schema' ) !== false ) {
+		if ( \check_admin_referer( 'yoast_seo_test_schema' ) !== false ) {
 			$this->option->set( 'replace_schema_domain', isset( $_POST['replace_schema_domain'] ) );
 		}
 
-		$is_needed_breadcrumb = $this->validate_submit( filter_input( INPUT_POST, 'is_needed_breadcrumb' ) );
-		$is_needed_webpage    = $this->validate_submit( filter_input( INPUT_POST, 'is_needed_webpage' ) );
+		$is_needed_breadcrumb = $this->validate_submit( \filter_input( INPUT_POST, 'is_needed_breadcrumb' ) );
+		$is_needed_webpage    = $this->validate_submit( \filter_input( INPUT_POST, 'is_needed_webpage' ) );
 
 		$this->option->set( 'is_needed_breadcrumb', $is_needed_breadcrumb );
 		$this->option->set( 'is_needed_webpage', $is_needed_webpage );
 
-		wp_safe_redirect( self_admin_url( 'tools.php?page=' . apply_filters( 'Yoast\WP\Test_Helper\admin_page', '' ) ) );
+		\wp_safe_redirect( \self_admin_url( 'tools.php?page=' . \apply_filters( 'Yoast\WP\Test_Helper\admin_page', '' ) ) );
 	}
 
 	/**
@@ -122,7 +122,7 @@ class Schema implements Integration {
 	 */
 	private function validate_submit( $value ) {
 		$value = (string) $value;
-		if ( in_array( $value, [ 'none', 'show', 'hide' ], true ) ) {
+		if ( \in_array( $value, [ 'none', 'show', 'hide' ], true ) ) {
 			return $value;
 		}
 		return 'none';
@@ -139,8 +139,8 @@ class Schema implements Integration {
 		$source = WPSEO_Utils::get_home_url();
 		$target = 'https://example.com';
 
-		if ( $source[ ( strlen( $source ) - 1 ) ] === '/' ) {
-			$source = substr( $source, 0, -1 );
+		if ( $source[ ( \strlen( $source ) - 1 ) ] === '/' ) {
+			$source = \substr( $source, 0, -1 );
 		}
 
 		return $this->array_value_str_replace( $source, $target, $data );
@@ -174,14 +174,14 @@ class Schema implements Integration {
 	 * @return array The array with needle replaced by replacement in strings.
 	 */
 	private function array_value_str_replace( $needle, $replacement, $array ) {
-		if ( is_array( $array ) ) {
+		if ( \is_array( $array ) ) {
 			foreach ( $array as $key => $value ) {
-				if ( is_array( $value ) ) {
+				if ( \is_array( $value ) ) {
 					$array[ $key ] = $this->array_value_str_replace( $needle, $replacement, $array[ $key ] );
 				}
 				else {
-					if ( strpos( $value, $needle ) !== false ) {
-						$array[ $key ] = str_replace( $needle, $replacement, $value );
+					if ( \strpos( $value, $needle ) !== false ) {
+						$array[ $key ] = \str_replace( $needle, $replacement, $value );
 					}
 				}
 			}

--- a/src/taxonomies.php
+++ b/src/taxonomies.php
@@ -76,7 +76,7 @@ class Taxonomies implements Integration {
 	 */
 	public function add_hooks() {
 		if ( $this->option->get( 'enable_post_types' ) === true ) {
-			add_action( 'init', [ $this, 'register_taxonomies' ] );
+			\add_action( 'init', [ $this, 'register_taxonomies' ] );
 		}
 	}
 
@@ -85,12 +85,12 @@ class Taxonomies implements Integration {
 	 */
 	public function register_taxonomies() {
 		// Taxonomies for books.
-		register_taxonomy( 'book-category', [ 'book' ], $this->set_slug( $this->category_args, 'yoast-test-book-category' ) );
-		register_taxonomy( 'book-genre', [ 'book' ], $this->set_slug( $this->genre_args, 'yoast-test-book-genre' ) );
+		\register_taxonomy( 'book-category', [ 'book' ], $this->set_slug( $this->category_args, 'yoast-test-book-category' ) );
+		\register_taxonomy( 'book-genre', [ 'book' ], $this->set_slug( $this->genre_args, 'yoast-test-book-genre' ) );
 
 		// Taxonomies for movies.
-		register_taxonomy( 'movie-category', [ 'movie' ], $this->set_slug( $this->category_args, 'yoast-test-movie-category' ) );
-		register_taxonomy( 'movie-genre', [ 'movie' ], $this->set_slug( $this->genre_args, 'yoast-test-movie-genre' ) );
+		\register_taxonomy( 'movie-category', [ 'movie' ], $this->set_slug( $this->category_args, 'yoast-test-movie-category' ) );
+		\register_taxonomy( 'movie-genre', [ 'movie' ], $this->set_slug( $this->genre_args, 'yoast-test-movie-genre' ) );
 	}
 
 	/**

--- a/src/upgrade-detector.php
+++ b/src/upgrade-detector.php
@@ -16,8 +16,8 @@ class Upgrade_Detector implements Integration {
 	 * @return void
 	 */
 	public function add_hooks() {
-		add_action( 'wpseo_run_upgrade', [ $this, 'yoast_seo_upgrade_ran' ] );
-		add_action( 'update_option_wpseo_premium_version', [ $this, 'yoast_seo_premium_upgrade_ran' ] );
+		\add_action( 'wpseo_run_upgrade', [ $this, 'yoast_seo_upgrade_ran' ] );
+		\add_action( 'update_option_wpseo_premium_version', [ $this, 'yoast_seo_premium_upgrade_ran' ] );
 	}
 
 	/**
@@ -47,6 +47,6 @@ class Upgrade_Detector implements Integration {
 	 */
 	private function add_notification( $notification_text ) {
 		$notification = new Notification( $notification_text, 'success' );
-		do_action( 'Yoast\WP\Test_Helper\notification', $notification );
+		\do_action( 'Yoast\WP\Test_Helper\notification', $notification );
 	}
 }

--- a/src/wordpress-plugin-features.php
+++ b/src/wordpress-plugin-features.php
@@ -35,7 +35,7 @@ class WordPress_Plugin_Features implements Integration {
 	 */
 	public function add_hooks() {
 		foreach ( $this->plugins as $plugin ) {
-			add_action(
+			\add_action(
 				'admin_post_' . $plugin->get_identifier() . '-feature-reset',
 				[ $this, 'handle_reset_feature' ]
 			);
@@ -48,9 +48,9 @@ class WordPress_Plugin_Features implements Integration {
 	 * @return string Combined features.
 	 */
 	public function get_controls() {
-		$output = array_map( [ $this, 'get_plugin_features' ], $this->plugins );
+		$output = \array_map( [ $this, 'get_plugin_features' ], $this->plugins );
 
-		return implode( '', $output );
+		return \implode( '', $output );
 	}
 
 	/**
@@ -68,19 +68,19 @@ class WordPress_Plugin_Features implements Integration {
 
 		$action = $plugin->get_identifier() . '-feature-reset';
 
-		$fields = implode(
+		$fields = \implode(
 			'',
-			array_map(
+			\array_map(
 				static function ( $name, $feature ) {
-					return sprintf(
+					return \sprintf(
 						'<button id="%s" name="%s" type="submit" class="button secondary">Reset %s</button> ',
-						esc_attr( $feature ) . '_button',
-						esc_attr( $feature ),
-						esc_html( $name )
+						\esc_attr( $feature ) . '_button',
+						\esc_attr( $feature ),
+						\esc_html( $name )
 					);
 				},
 				$features,
-				array_keys( $features )
+				\array_keys( $features )
 			)
 		);
 
@@ -96,7 +96,7 @@ class WordPress_Plugin_Features implements Integration {
 		foreach ( $this->plugins as $plugin ) {
 			$action = $plugin->get_identifier() . '-feature-reset';
 
-			if ( check_admin_referer( $action ) === false ) {
+			if ( \check_admin_referer( $action ) === false ) {
 				continue;
 			}
 
@@ -108,9 +108,9 @@ class WordPress_Plugin_Features implements Integration {
 			break;
 		}
 
-		wp_safe_redirect(
-			self_admin_url(
-				'tools.php?page=' . apply_filters( 'Yoast\WP\Test_Helper\admin_page', '' )
+		\wp_safe_redirect(
+			\self_admin_url(
+				'tools.php?page=' . \apply_filters( 'Yoast\WP\Test_Helper\admin_page', '' )
 			)
 		);
 	}
@@ -128,7 +128,7 @@ class WordPress_Plugin_Features implements Integration {
 				continue;
 			}
 
-			if ( check_admin_referer( $plugin->get_identifier() . '-feature-reset' ) === false ) {
+			if ( \check_admin_referer( $plugin->get_identifier() . '-feature-reset' ) === false ) {
 				continue;
 			}
 
@@ -144,7 +144,7 @@ class WordPress_Plugin_Features implements Integration {
 				);
 			}
 
-			do_action( 'Yoast\WP\Test_Helper\notification', $notification );
+			\do_action( 'Yoast\WP\Test_Helper\notification', $notification );
 		}
 	}
 }

--- a/src/wordpress-plugin-options.php
+++ b/src/wordpress-plugin-options.php
@@ -56,13 +56,13 @@ class WordPress_Plugin_Options {
 
 		$option_name = $this->get_option_name( $plugin );
 
-		$current_data           = (array) get_option( $option_name, [] );
-		$current_data[ time() ] = $data;
+		$current_data            = (array) \get_option( $option_name, [] );
+		$current_data[ \time() ] = $data;
 
 		// Only keep the 10 latest entries.
-		$current_data = array_slice( $current_data, -6, 6, true );
+		$current_data = \array_slice( $current_data, -6, 6, true );
 
-		return update_option( $this->get_option_name( $plugin ), $current_data, false );
+		return \update_option( $this->get_option_name( $plugin ), $current_data, false );
 	}
 
 	/**
@@ -99,7 +99,7 @@ class WordPress_Plugin_Options {
 			return [];
 		}
 
-		return maybe_unserialize( $result[0] );
+		return \maybe_unserialize( $result[0] );
 	}
 
 	/**
@@ -120,10 +120,10 @@ class WordPress_Plugin_Options {
 			$this->unhook_option_sanitization( $option_name );
 
 			if ( $option_value === [] ) {
-				delete_option( $option_name );
+				\delete_option( $option_name );
 			}
 			else {
-				update_option( $option_name, $option_value, false );
+				\update_option( $option_name, $option_value, false );
 			}
 
 			$this->hook_option_sanitization( $option_name );
@@ -141,9 +141,9 @@ class WordPress_Plugin_Options {
 	 */
 	public function unhook_option_sanitization( $option_name ) {
 		// Unhook option sanitization, otherwise the version cannot be changed.
-		if ( class_exists( WPSEO_Options::class ) ) {
+		if ( \class_exists( WPSEO_Options::class ) ) {
 			$option_instance = WPSEO_Options::get_option_instance( $option_name );
-			remove_filter( 'sanitize_option_' . $option_name, [ $option_instance, 'validate' ] );
+			\remove_filter( 'sanitize_option_' . $option_name, [ $option_instance, 'validate' ] );
 		}
 	}
 
@@ -155,9 +155,9 @@ class WordPress_Plugin_Options {
 	 * @return void
 	 */
 	public function hook_option_sanitization( $option_name ) {
-		if ( class_exists( WPSEO_Options::class ) ) {
+		if ( \class_exists( WPSEO_Options::class ) ) {
 			$option_instance = WPSEO_Options::get_option_instance( $option_name );
-			add_filter( 'sanitize_option_' . $option_name, [ $option_instance, 'validate' ] );
+			\add_filter( 'sanitize_option_' . $option_name, [ $option_instance, 'validate' ] );
 		}
 	}
 

--- a/src/wordpress-plugin-version.php
+++ b/src/wordpress-plugin-version.php
@@ -18,7 +18,7 @@ class WordPress_Plugin_Version {
 	 * @return string The version.
 	 */
 	public function get_version( WordPress_Plugin $plugin ) {
-		$data = get_option( $plugin->get_version_option_name() );
+		$data = \get_option( $plugin->get_version_option_name() );
 		if ( isset( $data[ $plugin->get_version_key() ] ) ) {
 			return $data[ $plugin->get_version_key() ];
 		}
@@ -36,14 +36,14 @@ class WordPress_Plugin_Version {
 	 */
 	public function update_version( WordPress_Plugin $plugin, $version ) {
 		$option_name = $plugin->get_version_option_name();
-		$data        = get_option( $option_name );
+		$data        = \get_option( $option_name );
 
 		if ( empty( $version ) ) {
 			return false;
 		}
 
 		if ( $plugin->get_version_key() === '' ) {
-			return update_option( $plugin->get_version_option_name(), $version );
+			return \update_option( $plugin->get_version_option_name(), $version );
 		}
 
 		if ( $data[ $plugin->get_version_key() ] === $version ) {
@@ -54,16 +54,16 @@ class WordPress_Plugin_Version {
 
 		$option_instance = false;
 		// Unhook option sanitization, otherwise the version cannot be changed.
-		if ( class_exists( WPSEO_Options::class ) ) {
+		if ( \class_exists( WPSEO_Options::class ) ) {
 			$option_instance = WPSEO_Options::get_option_instance( $option_name );
-			remove_filter( 'sanitize_option_' . $option_name, [ $option_instance, 'validate' ] );
+			\remove_filter( 'sanitize_option_' . $option_name, [ $option_instance, 'validate' ] );
 		}
 
-		$success = update_option( $option_name, $data );
+		$success = \update_option( $option_name, $data );
 
 		// Restore option sanitization.
 		if ( $option_instance ) {
-			add_filter( 'sanitize_option_' . $option_name, [ $option_instance, 'validate' ] );
+			\add_filter( 'sanitize_option_' . $option_name, [ $option_instance, 'validate' ] );
 		}
 
 		return $success;

--- a/src/wordpress-plugins/local-seo.php
+++ b/src/wordpress-plugins/local-seo.php
@@ -80,6 +80,6 @@ class Local_SEO implements WordPress_Plugin {
 	 * @return string The current version of the plugin.
 	 */
 	public function get_version_constant() {
-		return defined( 'WPSEO_LOCAL_VERSION' ) ? WPSEO_LOCAL_VERSION : 'not active';
+		return \defined( 'WPSEO_LOCAL_VERSION' ) ? WPSEO_LOCAL_VERSION : 'not active';
 	}
 }

--- a/src/wordpress-plugins/news-seo.php
+++ b/src/wordpress-plugins/news-seo.php
@@ -81,6 +81,6 @@ class News_SEO implements WordPress_Plugin {
 	 * @return string The current version of the plugin.
 	 */
 	public function get_version_constant() {
-		return class_exists( WPSEO_News::class ) ? WPSEO_News::VERSION : 'not active';
+		return \class_exists( WPSEO_News::class ) ? WPSEO_News::VERSION : 'not active';
 	}
 }

--- a/src/wordpress-plugins/video-seo.php
+++ b/src/wordpress-plugins/video-seo.php
@@ -80,6 +80,6 @@ class Video_SEO implements WordPress_Plugin {
 	 * @return string The current version of the plugin.
 	 */
 	public function get_version_constant() {
-		return defined( 'WPSEO_VIDEO_VERSION' ) ? WPSEO_VIDEO_VERSION : 'not active';
+		return \defined( 'WPSEO_VIDEO_VERSION' ) ? WPSEO_VIDEO_VERSION : 'not active';
 	}
 }

--- a/src/wordpress-plugins/woocommerce-seo.php
+++ b/src/wordpress-plugins/woocommerce-seo.php
@@ -81,6 +81,6 @@ class WooCommerce_SEO implements WordPress_Plugin {
 	 * @return string The current version of the plugin.
 	 */
 	public function get_version_constant() {
-		return class_exists( Yoast_WooCommerce_SEO::class ) ? Yoast_WooCommerce_SEO::VERSION : 'not active';
+		return \class_exists( Yoast_WooCommerce_SEO::class ) ? Yoast_WooCommerce_SEO::VERSION : 'not active';
 	}
 }

--- a/src/wordpress-plugins/yoast-seo-premium.php
+++ b/src/wordpress-plugins/yoast-seo-premium.php
@@ -81,6 +81,6 @@ class Yoast_SEO_Premium implements WordPress_Plugin {
 	 * @return string The current version of the plugin.
 	 */
 	public function get_version_constant() {
-		return defined( 'WPSEO_Premium::PLUGIN_VERSION_NAME' ) ? WPSEO_Premium::PLUGIN_VERSION_NAME : 'not active';
+		return \defined( 'WPSEO_Premium::PLUGIN_VERSION_NAME' ) ? WPSEO_Premium::PLUGIN_VERSION_NAME : 'not active';
 	}
 }

--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -117,7 +117,7 @@ class Yoast_SEO implements WordPress_Plugin {
 	 * @return string The current version of the plugin.
 	 */
 	public function get_version_constant() {
-		return defined( 'WPSEO_VERSION' ) ? WPSEO_VERSION : 'not active';
+		return \defined( 'WPSEO_VERSION' ) ? WPSEO_VERSION : 'not active';
 	}
 
 	/**
@@ -155,7 +155,7 @@ class Yoast_SEO implements WordPress_Plugin {
 			$wpdb->prefix . 'usermeta',
 			[
 				'meta_key' => 'wp_yoast_notifications',
-				'user_id'  => get_current_user_id(),
+				'user_id'  => \get_current_user_id(),
 			]
 		);
 
@@ -174,7 +174,7 @@ class Yoast_SEO implements WordPress_Plugin {
 	 * @return bool True if successful, false otherwise.
 	 */
 	private function reset_site_information() {
-		return delete_transient( 'wpseo_site_information' );
+		return \delete_transient( 'wpseo_site_information' );
 	}
 
 	/**
@@ -183,7 +183,7 @@ class Yoast_SEO implements WordPress_Plugin {
 	 * @return bool True if successful, false otherwise.
 	 */
 	private function reset_tracking() {
-		return delete_option( 'wpseo_tracking_last_request' );
+		return \delete_option( 'wpseo_tracking_last_request' );
 	}
 
 	/**
@@ -192,7 +192,7 @@ class Yoast_SEO implements WordPress_Plugin {
 	 * @return bool True if successful, false otherwise.
 	 */
 	private function reset_configuration_wizard() {
-		update_user_meta( get_current_user_id(), 'wpseo-dismiss-configuration-notice', 'no' );
+		\update_user_meta( \get_current_user_id(), 'wpseo-dismiss-configuration-notice', 'no' );
 
 		return WPSEO_Options::set( 'show_onboarding_notice', true );
 	}
@@ -212,7 +212,7 @@ class Yoast_SEO implements WordPress_Plugin {
 		$wpdb->query( 'DROP TABLE ' . $wpdb->prefix . 'yoast_primary_term' );
 		// phpcs:enable WordPress.DB.DirectDatabaseQuery.SchemaChange
 
-		delete_option( 'yoast_migrations_premium' );
-		return delete_option( 'yoast_migrations_free' );
+		\delete_option( 'yoast_migrations_premium' );
+		return \delete_option( 'yoast_migrations_free' );
 	}
 }

--- a/src/xml-sitemaps.php
+++ b/src/xml-sitemaps.php
@@ -32,11 +32,11 @@ class XML_Sitemaps implements Integration {
 	 */
 	public function add_hooks() {
 		if ( $this->option->get( 'disable_xml_sitemap_cache' ) === true ) {
-			add_filter( 'wpseo_enable_xml_sitemap_transient_caching', '__return_false' );
+			\add_filter( 'wpseo_enable_xml_sitemap_transient_caching', '__return_false' );
 		}
-		add_filter( 'wpseo_sitemap_entries_per_page', [ $this, 'xml_sitemap_entries' ], 10, 1 );
+		\add_filter( 'wpseo_sitemap_entries_per_page', [ $this, 'xml_sitemap_entries' ], 10, 1 );
 
-		add_action( 'admin_post_yoast_seo_test_xml_sitemaps', [ $this, 'handle_submit' ] );
+		\add_action( 'admin_post_yoast_seo_test_xml_sitemaps', [ $this, 'handle_submit' ] );
 	}
 
 	/**
@@ -61,7 +61,7 @@ class XML_Sitemaps implements Integration {
 	 */
 	public function get_controls() {
 		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Using WPSEO hook.
-		$placeholder = apply_filters( 'wpseo_sitemap_entries_per_page', 1000 );
+		$placeholder = \apply_filters( 'wpseo_sitemap_entries_per_page', 1000 );
 
 		$value = '';
 		if ( $this->option->get( 'xml_sitemap_entries' ) > 0 ) {
@@ -85,15 +85,15 @@ class XML_Sitemaps implements Integration {
 	 * @return void
 	 */
 	public function handle_submit() {
-		if ( check_admin_referer( 'yoast_seo_test_xml_sitemaps' ) !== false ) {
+		if ( \check_admin_referer( 'yoast_seo_test_xml_sitemaps' ) !== false ) {
 			$this->option->set( 'disable_xml_sitemap_cache', isset( $_POST['disable_xml_sitemap_cache'] ) );
 			$xml_sitemap_entries = null;
 			if ( isset( $_POST['xml_sitemap_entries'] ) ) {
-				$xml_sitemap_entries = filter_input( INPUT_POST, 'xml_sitemap_entries', FILTER_SANITIZE_NUMBER_INT );
+				$xml_sitemap_entries = \filter_input( INPUT_POST, 'xml_sitemap_entries', FILTER_SANITIZE_NUMBER_INT );
 			}
 			$this->option->set( 'xml_sitemap_entries', $xml_sitemap_entries );
 		}
 
-		wp_safe_redirect( self_admin_url( 'tools.php?page=' . apply_filters( 'Yoast\WP\Test_Helper\admin_page', '' ) ) );
+		\wp_safe_redirect( \self_admin_url( 'tools.php?page=' . \apply_filters( 'Yoast\WP\Test_Helper\admin_page', '' ) ) );
 	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Minor performance improvements.

## Relevant technical choices:

Using fully qualified names means that PHP won't have to look for the function in the current namespace before falling back to the global namespace, which gives a tiny performance boost for most functions and a larger one for a select list of PHP native functions using the OpCode cache (but only when at compile time it is clear that these function calls target the PHP native function).

## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

This PR can be tested by following these steps:

* _N/A_ No functional changes. All should still work as before.