### PR TITLE
PHPCS ruleset: iterate, add documentation and more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ artifact.zip
 /artifact/
 yarn-error.log
 /.wordpress-svn
+.phpcs.xml
+phpcs.xml
 
 ############
 ## OSes

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -40,6 +40,7 @@
 			<!-- Provide the plugin specific prefixes for all naming related sniffs. -->
 			<property name="prefixes" type="array">
 				<element value="Yoast\WP\Test_Helper"/>
+				<element value="yoast_test_helper"/>
 			</property>
 		</properties>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,43 +1,92 @@
 <?xml version="1.0"?>
-<ruleset name="Yoast Test Helper">
-    <description>Yoast Test Helper rules for PHP_CodeSniffer</description>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	name="Yoast Test Helper"
+	xsi:noNamespaceSchemaLocation="./vendor/squizlabs/php_codesniffer/phpcs.xsd">
 
-    <file>.</file>
+	<description>Yoast Test Helper rules for PHP_CodeSniffer</description>
 
-    <exclude-pattern>artifact/*</exclude-pattern>
+	<!--
+	#############################################################################
+	COMMAND LINE ARGUMENTS
+	https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+	#############################################################################
+	-->
 
-    <arg name="extensions" value="php"/>
-    <arg value="sp"/>
-    <arg name="basepath" value="./"/>
+	<file>.</file>
 
-    <rule ref="Yoast">
-        <properties>
-   			<!-- Provide the plugin specific prefixes for all naming related sniffs. -->
-   			<property name="prefixes" type="array">
-   				<element value="Yoast\WP\Test_Helper"/>
-   			</property>
-    	</properties>
-        <!-- We exclude this here because this is kind of the point of this plugin. -->
-        <exclude name="WordPress.DB.DirectDatabaseQuery.DirectQuery" />
-        <exclude name="WordPress.DB.DirectDatabaseQuery.NoCaching" />
-        <exclude name="WordPress.DB.SlowDBQuery.slow_db_query_meta_key" />
-    </rule>
+	<exclude-pattern>artifact/*</exclude-pattern>
 
-    <rule ref="Yoast.Files.FileName">
-        <properties>
-            <!-- Remove the following prefixes from the names of object structures. -->
-            <property name="oo_prefixes" type="array">
-                <element value="wpseo"/>
-    		</property>
-    	</properties>
-    </rule>
+	<!-- Only check PHP files. -->
+	<arg name="extensions" value="php"/>
 
-    <rule ref="Yoast.NamingConventions.NamespaceName">
-        <properties>
-            <!-- Treat the "src" directory as the project root for path to namespace translations. -->
-            <property name="src_directory" type="array">
-                <element value="src"/>
-            </property>
-        </properties>
-    </rule>
+	<!-- Show progress, show the error codes for each message (source). -->
+	<arg value="ps"/>
+
+	<!-- Strip the filepaths down to the relevant bit. -->
+	<arg name="basepath" value="./"/>
+
+	<!-- Check up to 8 files simultaneously. -->
+	<arg name="parallel" value="8"/>
+
+
+	<!--
+	#############################################################################
+	USE THE YoastCS RULESET
+	#############################################################################
+	-->
+
+	<rule ref="Yoast">
+		<properties>
+			<!-- Provide the plugin specific prefixes for all naming related sniffs. -->
+			<property name="prefixes" type="array">
+				<element value="Yoast\WP\Test_Helper"/>
+			</property>
+		</properties>
+
+		<!-- We exclude these here because this is kind of the point of this plugin. -->
+		<exclude name="WordPress.DB.DirectDatabaseQuery.DirectQuery" />
+		<exclude name="WordPress.DB.DirectDatabaseQuery.NoCaching" />
+		<exclude name="WordPress.DB.SlowDBQuery.slow_db_query_meta_key" />
+	</rule>
+
+
+	<!--
+	#############################################################################
+	SNIFF SPECIFIC CONFIGURATION
+	#############################################################################
+	-->
+
+	<!-- Verify that all gettext calls use the correct text domain. -->
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array">
+				<element value="yoast-test-helper"/>
+			</property>
+		</properties>
+	</rule>
+
+
+	<rule ref="Yoast.Files.FileName">
+		<properties>
+			<!-- Don't trigger on the main file as renaming it would deactivate the plugin. -->
+			<property name="excluded_files_strict_check" type="array">
+				<element value="yoast-test-helper.php"/>
+			</property>
+
+			<!-- Remove the following prefixes from the names of object structures. -->
+			<property name="oo_prefixes" type="array">
+				<element value="wpseo"/>
+			</property>
+		</properties>
+	</rule>
+
+	<rule ref="Yoast.NamingConventions.NamespaceName">
+		<properties>
+			<!-- Treat the "src" directory as the project root for path to namespace translations. -->
+			<property name="src_directory" type="array">
+				<element value="src"/>
+			</property>
+		</properties>
+	</rule>
+
 </ruleset>

--- a/yoast-test-helper.php
+++ b/yoast-test-helper.php
@@ -31,17 +31,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
 define( 'YOAST_TEST_HELPER_FILE', __FILE__ );
-// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
 define( 'YOAST_TEST_HELPER_DIR', dirname( YOAST_TEST_HELPER_FILE ) );
-// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
 define( 'YOAST_TEST_HELPER_VERSION', '1.5' );
 
 if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	require __DIR__ . '/vendor/autoload.php';
 }
 
-// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
 $yoast_test_helper = new Yoast\WP\Test_Helper\Plugin();
 $yoast_test_helper->add_hooks();


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Improved QA checks

## Relevant technical choices:

Follow up to PR #64 which addresses the remaining open points as per https://github.com/Yoast/yoast-test-helper/pull/64#issuecomment-608294316

@jdevalk There's nothing very exiting about this PR, but as it's a follow-up to your earlier PR I figured I'd tag you.

For the ruleset: it'll be easiest to review the changes with the "ignore whitespace changes" option turned on.

### PHPCS ruleset: iterate and add documentation

* Add the `text_domain` property for the `I18n` sniff.
* Explicitly exclude the main file from the strict file name check.
* Enable parallel scanning for faster results.

Additionally:
* Add the XSD schema tags.
* Add inline documentation.
* Consistently use tab-indentation.

### PHPCS config: allow for globals

The global variable and the global constants declared in the `yoast-test-helper.php` file _are_ prefixed, so let's just make sure PHPCS recognizes that instead of whitelisting the lines.

### .gitignore: ignore typical PHPCS overload files 


## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

This PR can be tested by following these steps:

* Run `vendorbin/phpcs` and see the build pass (or just check that Travis is green)
