### PR TITLE
Bug fix: fix fatal error / Debug bar panel

### DIFF
--- a/src/admin-bar-panel.php
+++ b/src/admin-bar-panel.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\Test_Helper;
 
 use Debug_Bar_Panel;
+use WPSEO_Options;
 
 /**
  * Class to manage registering and rendering the admin page in WordPress.

--- a/src/admin-debug-info.php
+++ b/src/admin-debug-info.php
@@ -2,7 +2,7 @@
 
 namespace Yoast\WP\Test_Helper;
 
-use Admin_Bar_Panel;
+use Yoast\WP\Test_Helper\Admin_Bar_Panel;
 use Yoast\WP\Test_Helper\Form_Presenter;
 use Yoast\WP\Test_Helper\Integration;
 use Yoast\WP\Test_Helper\Option;
@@ -45,14 +45,15 @@ class Admin_Debug_Info implements Integration {
 	/**
 	 * Makes the debug info appear in a Debug Bar panel.
 	 *
-	 * @param \Admin_Bar_Panel[] $panels Existing debug bar panels.
+	 * @param \Debug_Bar_Panel[] $panels Existing debug bar panels.
 	 *
-	 * @return \Admin_Bar_Panel[] Panels array.
+	 * @return \Debug_Bar_Panel[] Panels array.
 	 */
 	public function add_debug_panel( $panels ) {
 		if ( $this->option->get( 'show_options_debug' ) === true && \defined( 'WPSEO_VERSION' ) ) {
 			$panels[] = new Admin_Bar_Panel();
 		}
+
 		return $panels;
 	}
 
@@ -67,6 +68,7 @@ class Admin_Debug_Info implements Integration {
 			'Add Yoast SEO panel to <a href="https://wordpress.org/plugins/debug-bar/">Debug Bar</a>.',
 			$this->option->get( 'show_options_debug' )
 		);
+
 		return Form_Presenter::get_html( 'Debug Bar integration', 'yoast_seo_debug_settings', $fields );
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fix fatal error when used in combination with the Debug Bar plugin.

## Relevant technical choices:

The class `Yoast\WP\Test_Helper\WPSEO_Options` does not exist. To use the Yoast SEO Free `WPSEO_Options` class, it needs to be imported via a `use` statement or the name must be fully qualified inline.

Along the same lines, the `Admin_Bar_Panel` is a namespace local class, not a global one from the Debug Bar plugin.

## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

This PR can be tested by following these steps:

* While on `develop`, install & activate the [Debug Bar](https://wordpress.org/plugins/debug-bar/) plugin.
* See a fatal error on any page.
* Switch to this branch and see that the fatal error no longer occurs.

