### PR TITLE
Fix fatal on Admin_Bar_Panel by removing the imports

### DIFF
--- a/src/admin-debug-info.php
+++ b/src/admin-debug-info.php
@@ -2,11 +2,6 @@
 
 namespace Yoast\WP\Test_Helper;
 
-use Admin_Bar_Panel;
-use Yoast\WP\Test_Helper\Form_Presenter;
-use Yoast\WP\Test_Helper\Integration;
-use Yoast\WP\Test_Helper\Option;
-
 /**
  * Class to manage registering and rendering the admin page in WordPress.
  */
@@ -15,14 +10,14 @@ class Admin_Debug_Info implements Integration {
 	/**
 	 * Holds our option instance.
 	 *
-	 * @var \Yoast\WP\Test_Helper\Option
+	 * @var Option
 	 */
 	private $option;
 
 	/**
 	 * Class constructor.
 	 *
-	 * @param \Yoast\WP\Test_Helper\Option $option Our option array.
+	 * @param Option $option Our option array.
 	 */
 	public function __construct( Option $option ) {
 		$this->option = $option;
@@ -45,14 +40,15 @@ class Admin_Debug_Info implements Integration {
 	/**
 	 * Makes the debug info appear in a Debug Bar panel.
 	 *
-	 * @param \Admin_Bar_Panel[] $panels Existing debug bar panels.
+	 * @param Admin_Bar_Panel[] $panels Existing debug bar panels.
 	 *
-	 * @return \Admin_Bar_Panel[] Panels array.
+	 * @return Admin_Bar_Panel[] Panels array.
 	 */
 	public function add_debug_panel( $panels ) {
 		if ( $this->option->get( 'show_options_debug' ) === true && \defined( 'WPSEO_VERSION' ) ) {
 			$panels[] = new Admin_Bar_Panel();
 		}
+
 		return $panels;
 	}
 
@@ -67,6 +63,7 @@ class Admin_Debug_Info implements Integration {
 			'Add Yoast SEO panel to <a href="https://wordpress.org/plugins/debug-bar/">Debug Bar</a>.',
 			$this->option->get( 'show_options_debug' )
 		);
+
 		return Form_Presenter::get_html( 'Debug Bar integration', 'yoast_seo_debug_settings', $fields );
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a fatal error because the Admin_Bar_Panel was used from a wrong namespace.

## Relevant technical choices:

* Removed the imports altogether because they all live in the same namespace that the file is already in.

## Milestone

* [ ] I've attached the next release's milestone to this pull request.

## Test instructions

This PR can be tested by following these steps:

* Before you would get a fatal error when the plugin was activated.
* Now it works fine.

Fixes #
