### PR TITLE
CS: revert "use FQN in docblocks"

### DIFF
--- a/src/admin-debug-info.php
+++ b/src/admin-debug-info.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\Test_Helper;
 
+use Debug_Bar_Panel;
 use Yoast\WP\Test_Helper\Admin_Bar_Panel;
 use Yoast\WP\Test_Helper\Form_Presenter;
 use Yoast\WP\Test_Helper\Integration;
@@ -15,14 +16,14 @@ class Admin_Debug_Info implements Integration {
 	/**
 	 * Holds our option instance.
 	 *
-	 * @var \Yoast\WP\Test_Helper\Option
+	 * @var Option
 	 */
 	private $option;
 
 	/**
 	 * Class constructor.
 	 *
-	 * @param \Yoast\WP\Test_Helper\Option $option Our option array.
+	 * @param Option $option Our option array.
 	 */
 	public function __construct( Option $option ) {
 		$this->option = $option;
@@ -45,9 +46,9 @@ class Admin_Debug_Info implements Integration {
 	/**
 	 * Makes the debug info appear in a Debug Bar panel.
 	 *
-	 * @param \Debug_Bar_Panel[] $panels Existing debug bar panels.
+	 * @param Debug_Bar_Panel[] $panels Existing debug bar panels.
 	 *
-	 * @return \Debug_Bar_Panel[] Panels array.
+	 * @return Debug_Bar_Panel[] Panels array.
 	 */
 	public function add_debug_panel( $panels ) {
 		if ( $this->option->get( 'show_options_debug' ) === true && \defined( 'WPSEO_VERSION' ) ) {

--- a/src/admin-notifications.php
+++ b/src/admin-notifications.php
@@ -13,7 +13,7 @@ class Admin_Notifications implements Integration {
 	/**
 	 * List of notifications.
 	 *
-	 * @var \Yoast\WP\Test_Helper\Notification[]
+	 * @var Notification[]
 	 */
 	protected $notifications;
 
@@ -30,7 +30,7 @@ class Admin_Notifications implements Integration {
 	/**
 	 * Adds a notification to the stack.
 	 *
-	 * @param \Yoast\WP\Test_Helper\Notification $notification Notification to add.
+	 * @param Notification $notification Notification to add.
 	 *
 	 * @return void
 	 */
@@ -64,7 +64,7 @@ class Admin_Notifications implements Integration {
 	/**
 	 * Retrieves the list of notifications.
 	 *
-	 * @return \Yoast\WP\Test_Helper\Notification[] List of notifications.
+	 * @return Notification[] List of notifications.
 	 */
 	protected function get_notifications() {
 		$saved = \get_user_meta( \get_current_user_id(), $this->get_option_name(), true );
@@ -87,7 +87,7 @@ class Admin_Notifications implements Integration {
 	/**
 	 * Saves the notifications for the next page request.
 	 *
-	 * @param \Yoast\WP\Test_Helper\Notification[] $notifications Notifications to save.
+	 * @param Notification[] $notifications Notifications to save.
 	 *
 	 * @return void
 	 */

--- a/src/development-mode.php
+++ b/src/development-mode.php
@@ -14,14 +14,14 @@ class Development_Mode implements Integration {
 	/**
 	 * Holds our option instance.
 	 *
-	 * @var \Yoast\WP\Test_Helper\Option
+	 * @var Option
 	 */
 	private $option;
 
 	/**
 	 * Class constructor.
 	 *
-	 * @param \Yoast\WP\Test_Helper\Option $option Our option array.
+	 * @param Option $option Our option array.
 	 */
 	public function __construct( Option $option ) {
 		$this->option = $option;

--- a/src/domain-dropdown.php
+++ b/src/domain-dropdown.php
@@ -14,14 +14,14 @@ class Domain_Dropdown implements Integration {
 	/**
 	 * Holds our option instance.
 	 *
-	 * @var \Yoast\WP\Test_Helper\Option
+	 * @var Option
 	 */
 	private $option;
 
 	/**
 	 * Class constructor.
 	 *
-	 * @param \Yoast\WP\Test_Helper\Option $option Our option array.
+	 * @param Option $option Our option array.
 	 */
 	public function __construct( Option $option ) {
 		$this->option = $option;

--- a/src/feature-toggler.php
+++ b/src/feature-toggler.php
@@ -21,14 +21,14 @@ class Feature_Toggler implements Integration {
 	/**
 	 * Holds our option instance.
 	 *
-	 * @var \Yoast\WP\Test_Helper\Option
+	 * @var Option
 	 */
 	private $option;
 
 	/**
 	 * Class constructor.
 	 *
-	 * @param \Yoast\WP\Test_Helper\Option $option Our option array.
+	 * @param Option $option Our option array.
 	 */
 	public function __construct( Option $option ) {
 		$this->option = $option;

--- a/src/inline-script.php
+++ b/src/inline-script.php
@@ -14,14 +14,14 @@ class Inline_Script implements Integration {
 	/**
 	 * Holds our option instance.
 	 *
-	 * @var \Yoast\WP\Test_Helper\Option
+	 * @var Option
 	 */
 	private $option;
 
 	/**
 	 * Class constructor.
 	 *
-	 * @param \Yoast\WP\Test_Helper\Option $option Our option array.
+	 * @param Option $option Our option array.
 	 */
 	public function __construct( Option $option ) {
 		$this->option = $option;

--- a/src/plugin-toggler.php
+++ b/src/plugin-toggler.php
@@ -29,14 +29,14 @@ class Plugin_Toggler implements Integration {
 	/**
 	 * Holds our option instance.
 	 *
-	 * @var \Yoast\WP\Test_Helper\Option
+	 * @var Option
 	 */
 	private $option;
 
 	/**
 	 * Class constructor.
 	 *
-	 * @param \Yoast\WP\Test_Helper\Option $option Our option array.
+	 * @param Option $option Our option array.
 	 */
 	public function __construct( Option $option ) {
 		$this->option = $option;

--- a/src/plugin-version-control.php
+++ b/src/plugin-version-control.php
@@ -17,30 +17,30 @@ class Plugin_Version_Control implements Integration {
 	/**
 	 * The plugin version instance to use.
 	 *
-	 * @var \Yoast\WP\Test_Helper\WordPress_Plugin_Version
+	 * @var WordPress_Plugin_Version
 	 */
 	protected $plugin_version;
 
 	/**
 	 * The plugin options to use.
 	 *
-	 * @var \Yoast\WP\Test_Helper\WordPress_Plugin_Options
+	 * @var WordPress_Plugin_Options
 	 */
 	protected $plugin_options;
 
 	/**
 	 * The list of plugins to use.
 	 *
-	 * @var \Yoast\WP\Test_Helper\WordPress_Plugins\WordPress_Plugin[]
+	 * @var WordPress_Plugin[]
 	 */
 	protected $plugins;
 
 	/**
 	 * WordPress_Plugin_Version_Control constructor.
 	 *
-	 * @param array                                          $plugins        Plugins to use.
-	 * @param \Yoast\WP\Test_Helper\WordPress_Plugin_Version $plugin_version Plugin version to use.
-	 * @param \Yoast\WP\Test_Helper\WordPress_Plugin_Options $plugin_options Plugin options to use.
+	 * @param array                    $plugins        Plugins to use.
+	 * @param WordPress_Plugin_Version $plugin_version Plugin version to use.
+	 * @param WordPress_Plugin_Options $plugin_options Plugin options to use.
 	 */
 	public function __construct(
 		array $plugins,
@@ -103,8 +103,8 @@ class Plugin_Version_Control implements Integration {
 	/**
 	 * Updates the plugin version.
 	 *
-	 * @param \Yoast\WP\Test_Helper\WordPress_Plugins\WordPress_Plugin $plugin  Plugin to update a version of.
-	 * @param string                                                   $version Version to update.
+	 * @param WordPress_Plugin $plugin  Plugin to update a version of.
+	 * @param string           $version Version to update.
 	 */
 	protected function update_plugin_version( WordPress_Plugin $plugin, $version ) {
 		if ( $this->plugin_version->update_version( $plugin, $version ) ) {
@@ -125,7 +125,7 @@ class Plugin_Version_Control implements Integration {
 	/**
 	 * Retrieves a plugin option.
 	 *
-	 * @param \Yoast\WP\Test_Helper\WordPress_Plugins\WordPress_Plugin $plugin Plugin to retrieve the option of.
+	 * @param WordPress_Plugin $plugin Plugin to retrieve the option of.
 	 *
 	 * @return string The plugin option.
 	 */
@@ -143,7 +143,7 @@ class Plugin_Version_Control implements Integration {
 	/**
 	 * Retrieves the plugin stored options history.
 	 *
-	 * @param \Yoast\WP\Test_Helper\WordPress_Plugins\WordPress_Plugin $plugin Plugin to retrieve the history of.
+	 * @param WordPress_Plugin $plugin Plugin to retrieve the history of.
 	 *
 	 * @return string The plugin option history.
 	 */

--- a/src/plugin.php
+++ b/src/plugin.php
@@ -37,7 +37,7 @@ class Plugin implements Integration {
 	/**
 	 * List of integrations
 	 *
-	 * @var \Yoast\WP\Test_Helper\Integration[]
+	 * @var Integration[]
 	 */
 	protected $integrations = [];
 
@@ -67,7 +67,7 @@ class Plugin implements Integration {
 	/**
 	 * Adds the blocks to the admin page.
 	 *
-	 * @param \Yoast\WP\Test_Helper\Admin_Page $admin_page The current admin page.
+	 * @param Admin_Page $admin_page The current admin page.
 	 */
 	public function admin_page_blocks( Admin_Page $admin_page ) {
 		foreach ( $this->integrations as $integration ) {

--- a/src/post-types.php
+++ b/src/post-types.php
@@ -14,7 +14,7 @@ class Post_Types implements Integration {
 	/**
 	 * Holds our option instance.
 	 *
-	 * @var \Yoast\WP\Test_Helper\Option
+	 * @var Option
 	 */
 	private $option;
 
@@ -67,7 +67,7 @@ class Post_Types implements Integration {
 	/**
 	 * Class constructor.
 	 *
-	 * @param \Yoast\WP\Test_Helper\Option $option Our option array.
+	 * @param Option $option Our option array.
 	 */
 	public function __construct( Option $option ) {
 		$this->option = $option;

--- a/src/schema.php
+++ b/src/schema.php
@@ -15,14 +15,14 @@ class Schema implements Integration {
 	/**
 	 * Holds our option instance.
 	 *
-	 * @var \Yoast\WP\Test_Helper\Option
+	 * @var Option
 	 */
 	private $option;
 
 	/**
 	 * Class constructor.
 	 *
-	 * @param \Yoast\WP\Test_Helper\Option $option Our option array.
+	 * @param Option $option Our option array.
 	 */
 	public function __construct( Option $option ) {
 		$this->option = $option;

--- a/src/taxonomies.php
+++ b/src/taxonomies.php
@@ -13,7 +13,7 @@ class Taxonomies implements Integration {
 	/**
 	 * Holds our option instance.
 	 *
-	 * @var \Yoast\WP\Test_Helper\Option
+	 * @var Option
 	 */
 	private $option;
 
@@ -65,7 +65,7 @@ class Taxonomies implements Integration {
 	/**
 	 * Class constructor.
 	 *
-	 * @param \Yoast\WP\Test_Helper\Option $option Our option array.
+	 * @param Option $option Our option array.
 	 */
 	public function __construct( Option $option ) {
 		$this->option = $option;

--- a/src/wordpress-plugin-features.php
+++ b/src/wordpress-plugin-features.php
@@ -15,14 +15,14 @@ class WordPress_Plugin_Features implements Integration {
 	/**
 	 * Plugins to use.
 	 *
-	 * @var \Yoast\WP\Test_Helper\WordPress_Plugins\WordPress_Plugin[]
+	 * @var WordPress_Plugin[]
 	 */
 	protected $plugins;
 
 	/**
 	 * WordPress_Plugin_Features constructor.
 	 *
-	 * @param \Yoast\WP\Test_Helper\WordPress_Plugins\WordPress_Plugin[] $plugins Plugins to use.
+	 * @param WordPress_Plugin[] $plugins Plugins to use.
 	 */
 	public function __construct( $plugins ) {
 		$this->plugins = $plugins;
@@ -56,7 +56,7 @@ class WordPress_Plugin_Features implements Integration {
 	/**
 	 * Retrieves the plugin features of a specific plugin.
 	 *
-	 * @param \Yoast\WP\Test_Helper\WordPress_Plugins\WordPress_Plugin $plugin Plugin to retrieve the features of.
+	 * @param WordPress_Plugin $plugin Plugin to retrieve the features of.
 	 *
 	 * @return string Combined plugin features.
 	 */
@@ -118,7 +118,7 @@ class WordPress_Plugin_Features implements Integration {
 	/**
 	 * Detects if a feature must be reset for a specific plugin.
 	 *
-	 * @param \Yoast\WP\Test_Helper\WordPress_Plugins\WordPress_Plugin $plugin Plugin to reset a feature of.
+	 * @param WordPress_Plugin $plugin Plugin to reset a feature of.
 	 *
 	 * @return void
 	 */

--- a/src/wordpress-plugin-options.php
+++ b/src/wordpress-plugin-options.php
@@ -13,7 +13,7 @@ class WordPress_Plugin_Options {
 	/**
 	 * Saves the options for a specific plugin.
 	 *
-	 * @param \Yoast\WP\Test_Helper\WordPress_Plugins\WordPress_Plugin $plugin The plugin to save options of.
+	 * @param WordPress_Plugin $plugin The plugin to save options of.
 	 *
 	 * @return bool True if options were saved.
 	 */
@@ -44,8 +44,8 @@ class WordPress_Plugin_Options {
 	/**
 	 * Stores the data of a specific plugin.
 	 *
-	 * @param \Yoast\WP\Test_Helper\WordPress_Plugins\WordPress_Plugin $plugin Plugin to store data of.
-	 * @param array                                                    $data   Data to store.
+	 * @param WordPress_Plugin $plugin Plugin to store data of.
+	 * @param array            $data   Data to store.
 	 *
 	 * @return bool True if stored.
 	 */
@@ -68,7 +68,7 @@ class WordPress_Plugin_Options {
 	/**
 	 * Retrieves saved options for a specific plugin.
 	 *
-	 * @param \Yoast\WP\Test_Helper\WordPress_Plugins\WordPress_Plugin $plugin Plugin to retrieve options of.
+	 * @param WordPress_Plugin $plugin Plugin to retrieve options of.
 	 *
 	 * @return array Stored data.
 	 */
@@ -105,8 +105,8 @@ class WordPress_Plugin_Options {
 	/**
 	 * Restores options of a specific plugin.
 	 *
-	 * @param \Yoast\WP\Test_Helper\WordPress_Plugins\WordPress_Plugin $plugin    Plugin to restore options of.
-	 * @param int                                                      $timestamp Specific save point to restore.
+	 * @param WordPress_Plugin $plugin    Plugin to restore options of.
+	 * @param int              $timestamp Specific save point to restore.
 	 *
 	 * @return bool True on succes.
 	 */
@@ -164,7 +164,7 @@ class WordPress_Plugin_Options {
 	/**
 	 * Returns the option name which stores the option data of a specific plugin.
 	 *
-	 * @param \Yoast\WP\Test_Helper\WordPress_Plugins\WordPress_Plugin $plugin The plugin.
+	 * @param WordPress_Plugin $plugin The plugin.
 	 *
 	 * @return string The option name the data should be stored in.
 	 */

--- a/src/wordpress-plugin-version.php
+++ b/src/wordpress-plugin-version.php
@@ -13,7 +13,7 @@ class WordPress_Plugin_Version {
 	/**
 	 * Retrieves the version of a specific plugin.
 	 *
-	 * @param \Yoast\WP\Test_Helper\WordPress_Plugins\WordPress_Plugin $plugin Plugin to retrieve the version of.
+	 * @param WordPress_Plugin $plugin Plugin to retrieve the version of.
 	 *
 	 * @return string The version.
 	 */
@@ -29,8 +29,8 @@ class WordPress_Plugin_Version {
 	/**
 	 * Stores a plugin version.
 	 *
-	 * @param \Yoast\WP\Test_Helper\WordPress_Plugins\WordPress_Plugin $plugin  Plugin to store the version of.
-	 * @param string                                                   $version The version to store.
+	 * @param WordPress_Plugin $plugin  Plugin to store the version of.
+	 * @param string           $version The version to store.
 	 *
 	 * @return bool True on succes.
 	 */

--- a/src/xml-sitemaps.php
+++ b/src/xml-sitemaps.php
@@ -14,14 +14,14 @@ class XML_Sitemaps implements Integration {
 	/**
 	 * Holds our option instance.
 	 *
-	 * @var \Yoast\WP\Test_Helper\Option
+	 * @var Option
 	 */
 	private $option;
 
 	/**
 	 * Class constructor.
 	 *
-	 * @param \Yoast\WP\Test_Helper\Option $option Our option array.
+	 * @param Option $option Our option array.
 	 */
 	public function __construct( Option $option ) {
 		$this->option = $option;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Code consistency

## Relevant technical choices:

Use unqualified names instead and if it involves a class from another namespace and no `use` statement is in place yet, add an import `use` statement.

## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

This PR can be tested by following these steps:

* _N/A_ (no functional changes)

