### PR TITLE
CS: partially revert "always use `use` statements"

### DIFF
--- a/src/admin-debug-info.php
+++ b/src/admin-debug-info.php
@@ -3,10 +3,6 @@
 namespace Yoast\WP\Test_Helper;
 
 use Debug_Bar_Panel;
-use Yoast\WP\Test_Helper\Admin_Bar_Panel;
-use Yoast\WP\Test_Helper\Form_Presenter;
-use Yoast\WP\Test_Helper\Integration;
-use Yoast\WP\Test_Helper\Option;
 
 /**
  * Class to manage registering and rendering the admin page in WordPress.

--- a/src/admin-notifications.php
+++ b/src/admin-notifications.php
@@ -2,9 +2,6 @@
 
 namespace Yoast\WP\Test_Helper;
 
-use Yoast\WP\Test_Helper\Integration;
-use Yoast\WP\Test_Helper\Notification;
-
 /**
  * Shows admin notifications on the proper page.
  */

--- a/src/admin-page.php
+++ b/src/admin-page.php
@@ -2,8 +2,6 @@
 
 namespace Yoast\WP\Test_Helper;
 
-use Yoast\WP\Test_Helper\Integration;
-
 /**
  * Class to manage registering and rendering the admin page in WordPress.
  */

--- a/src/development-mode.php
+++ b/src/development-mode.php
@@ -2,10 +2,6 @@
 
 namespace Yoast\WP\Test_Helper;
 
-use Yoast\WP\Test_Helper\Integration;
-use Yoast\WP\Test_Helper\Form_Presenter;
-use Yoast\WP\Test_Helper\Option;
-
 /**
  * Shows admin notifications on the proper page.
  */

--- a/src/domain-dropdown.php
+++ b/src/domain-dropdown.php
@@ -2,10 +2,6 @@
 
 namespace Yoast\WP\Test_Helper;
 
-use Yoast\WP\Test_Helper\Form_Presenter;
-use Yoast\WP\Test_Helper\Integration;
-use Yoast\WP\Test_Helper\Option;
-
 /**
  * Sends myYoast requests to a chosen testing domain.
  */

--- a/src/feature-toggler.php
+++ b/src/feature-toggler.php
@@ -2,10 +2,6 @@
 
 namespace Yoast\WP\Test_Helper;
 
-use Yoast\WP\Test_Helper\Form_Presenter;
-use Yoast\WP\Test_Helper\Integration;
-use Yoast\WP\Test_Helper\Option;
-
 /**
  * Toggles the features on and off.
  */

--- a/src/inline-script.php
+++ b/src/inline-script.php
@@ -2,10 +2,6 @@
 
 namespace Yoast\WP\Test_Helper;
 
-use Yoast\WP\Test_Helper\Form_Presenter;
-use Yoast\WP\Test_Helper\Integration;
-use Yoast\WP\Test_Helper\Option;
-
 /**
  * Class to add an inline script after a wordpress-seo script.
  */

--- a/src/plugin-toggler.php
+++ b/src/plugin-toggler.php
@@ -3,9 +3,6 @@
 namespace Yoast\WP\Test_Helper;
 
 use WPSEO_Utils;
-use Yoast\WP\Test_Helper\Form_Presenter;
-use Yoast\WP\Test_Helper\Integration;
-use Yoast\WP\Test_Helper\Option;
 
 /**
  * Toggles between plugins.

--- a/src/plugin-version-control.php
+++ b/src/plugin-version-control.php
@@ -2,11 +2,6 @@
 
 namespace Yoast\WP\Test_Helper;
 
-use Yoast\WP\Test_Helper\Form_Presenter;
-use Yoast\WP\Test_Helper\Integration;
-use Yoast\WP\Test_Helper\Notification;
-use Yoast\WP\Test_Helper\WordPress_Plugin_Options;
-use Yoast\WP\Test_Helper\WordPress_Plugin_Version;
 use Yoast\WP\Test_Helper\WordPress_Plugins\WordPress_Plugin;
 
 /**

--- a/src/plugin.php
+++ b/src/plugin.php
@@ -2,24 +2,6 @@
 
 namespace Yoast\WP\Test_Helper;
 
-use Yoast\WP\Test_Helper\Admin_Debug_Info;
-use Yoast\WP\Test_Helper\Admin_Notifications;
-use Yoast\WP\Test_Helper\Admin_Page;
-use Yoast\WP\Test_Helper\Development_Mode;
-use Yoast\WP\Test_Helper\Domain_Dropdown;
-use Yoast\WP\Test_Helper\Feature_Toggler;
-use Yoast\WP\Test_Helper\Inline_Script;
-use Yoast\WP\Test_Helper\Integration;
-use Yoast\WP\Test_Helper\Option;
-use Yoast\WP\Test_Helper\Post_Types;
-use Yoast\WP\Test_Helper\Plugin_Toggler;
-use Yoast\WP\Test_Helper\Plugin_Version_Control;
-use Yoast\WP\Test_Helper\Schema;
-use Yoast\WP\Test_Helper\Taxonomies;
-use Yoast\WP\Test_Helper\Upgrade_Detector;
-use Yoast\WP\Test_Helper\WordPress_Plugin_Features;
-use Yoast\WP\Test_Helper\WordPress_Plugin_Options;
-use Yoast\WP\Test_Helper\WordPress_Plugin_Version;
 use Yoast\WP\Test_Helper\WordPress_Plugins\Local_SEO;
 use Yoast\WP\Test_Helper\WordPress_Plugins\News_SEO;
 use Yoast\WP\Test_Helper\WordPress_Plugins\Video_SEO;
@@ -27,7 +9,6 @@ use Yoast\WP\Test_Helper\WordPress_Plugins\WooCommerce_SEO;
 use Yoast\WP\Test_Helper\WordPress_Plugins\WordPress_Plugin;
 use Yoast\WP\Test_Helper\WordPress_Plugins\Yoast_SEO;
 use Yoast\WP\Test_Helper\WordPress_Plugins\Yoast_SEO_Premium;
-use Yoast\WP\Test_Helper\XML_Sitemaps;
 
 /**
  * Bootstrap for the entire plugin.

--- a/src/post-types.php
+++ b/src/post-types.php
@@ -2,10 +2,6 @@
 
 namespace Yoast\WP\Test_Helper;
 
-use Yoast\WP\Test_Helper\Form_Presenter;
-use Yoast\WP\Test_Helper\Integration;
-use Yoast\WP\Test_Helper\Option;
-
 /**
  * Bootstrap for the entire plugin.
  */

--- a/src/schema.php
+++ b/src/schema.php
@@ -3,9 +3,6 @@
 namespace Yoast\WP\Test_Helper;
 
 use WPSEO_Utils;
-use Yoast\WP\Test_Helper\Form_Presenter;
-use Yoast\WP\Test_Helper\Integration;
-use Yoast\WP\Test_Helper\Option;
 
 /**
  * Class to manage registering and rendering the admin page in WordPress.

--- a/src/taxonomies.php
+++ b/src/taxonomies.php
@@ -2,9 +2,6 @@
 
 namespace Yoast\WP\Test_Helper;
 
-use Yoast\WP\Test_Helper\Integration;
-use Yoast\WP\Test_Helper\Option;
-
 /**
  * Bootstrap for the entire plugin.
  */

--- a/src/upgrade-detector.php
+++ b/src/upgrade-detector.php
@@ -2,9 +2,6 @@
 
 namespace Yoast\WP\Test_Helper;
 
-use Yoast\WP\Test_Helper\Integration;
-use Yoast\WP\Test_Helper\Notification;
-
 /**
  * Upgrade detector, spawns a notification if an upgrade is being run.
  */

--- a/src/wordpress-plugin-features.php
+++ b/src/wordpress-plugin-features.php
@@ -2,9 +2,6 @@
 
 namespace Yoast\WP\Test_Helper;
 
-use Yoast\WP\Test_Helper\Form_Presenter;
-use Yoast\WP\Test_Helper\Integration;
-use Yoast\WP\Test_Helper\Notification;
 use Yoast\WP\Test_Helper\WordPress_Plugins\WordPress_Plugin;
 
 /**

--- a/src/wordpress-plugins/local-seo.php
+++ b/src/wordpress-plugins/local-seo.php
@@ -2,8 +2,6 @@
 
 namespace Yoast\WP\Test_Helper\WordPress_Plugins;
 
-use Yoast\WP\Test_Helper\WordPress_Plugins\WordPress_Plugin;
-
 /**
  * Class to represent Local SEO.
  */

--- a/src/wordpress-plugins/news-seo.php
+++ b/src/wordpress-plugins/news-seo.php
@@ -3,7 +3,6 @@
 namespace Yoast\WP\Test_Helper\WordPress_Plugins;
 
 use WPSEO_News;
-use Yoast\WP\Test_Helper\WordPress_Plugins\WordPress_Plugin;
 
 /**
  * Class to represent News SEO.

--- a/src/wordpress-plugins/video-seo.php
+++ b/src/wordpress-plugins/video-seo.php
@@ -2,8 +2,6 @@
 
 namespace Yoast\WP\Test_Helper\WordPress_Plugins;
 
-use Yoast\WP\Test_Helper\WordPress_Plugins\WordPress_Plugin;
-
 /**
  * Class to represent Video SEO.
  */

--- a/src/wordpress-plugins/woocommerce-seo.php
+++ b/src/wordpress-plugins/woocommerce-seo.php
@@ -3,7 +3,6 @@
 namespace Yoast\WP\Test_Helper\WordPress_Plugins;
 
 use Yoast_WooCommerce_SEO;
-use Yoast\WP\Test_Helper\WordPress_Plugins\WordPress_Plugin;
 
 /**
  * Class to represent WooCommerce SEO.

--- a/src/wordpress-plugins/yoast-seo-premium.php
+++ b/src/wordpress-plugins/yoast-seo-premium.php
@@ -3,7 +3,6 @@
 namespace Yoast\WP\Test_Helper\WordPress_Plugins;
 
 use WPSEO_Premium;
-use Yoast\WP\Test_Helper\WordPress_Plugins\WordPress_Plugin;
 
 /**
  * Class to represent Local SEO.

--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -3,7 +3,6 @@
 namespace Yoast\WP\Test_Helper\WordPress_Plugins;
 
 use WPSEO_Options;
-use Yoast\WP\Test_Helper\WordPress_Plugins\WordPress_Plugin;
 
 /**
  * Class to represent Yoast SEO.

--- a/src/xml-sitemaps.php
+++ b/src/xml-sitemaps.php
@@ -2,10 +2,6 @@
 
 namespace Yoast\WP\Test_Helper;
 
-use Yoast\WP\Test_Helper\Form_Presenter;
-use Yoast\WP\Test_Helper\Integration;
-use Yoast\WP\Test_Helper\Option;
-
 /**
  * Class to manage registering and rendering the admin page in WordPress.
  */


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Code consistency

## Relevant technical choices:

Import `use` statements for classes in the same namespace will not be allowed. This was decided yesterday in contrast to before.

## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

This PR can be tested by following these steps:

* _N/A_ (no functional changes)