### PR TITLE
Update reset configuration wizard function

### DIFF
--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -191,7 +191,6 @@ class Yoast_SEO implements WordPress_Plugin {
 	 * @return bool True if successful, false otherwise.
 	 */
 	private function reset_configuration_wizard() {
-		\update_user_meta( \get_current_user_id(), 'wpseo-dismiss-configuration-notice', 'no' );
 
 		if ( WPSEO_Options::set( 'started_configuration_wizard', false ) && WPSEO_Options::set( 'show_onboarding_notice', true ) ) {
 			return true;

--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -193,7 +193,10 @@ class Yoast_SEO implements WordPress_Plugin {
 	private function reset_configuration_wizard() {
 		\update_user_meta( \get_current_user_id(), 'wpseo-dismiss-configuration-notice', 'no' );
 
-		return WPSEO_Options::set( 'show_onboarding_notice', true );
+		if ( WPSEO_Options::set( 'started_configuration_wizard', false ) && WPSEO_Options::set( 'show_onboarding_notice', true ) ) {
+			return true;
+		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Updates the reset_configuration_wizard function according to the changes in https://github.com/Yoast/wordpress-seo/pull/14917

## Relevant technical choices:
IMPORTANT NOTICE
This should only be merged after https://github.com/Yoast/wordpress-seo/pull/14917 is merged into admin-redesign and that that branch is merged into trunk.
* The WPSEO_Options option called started_configuration_wizard is reset to false in the newly updated method.

## Milestone

* [X] I've attached the next release's milestone to this pull request.

## Test instructions

This PR can be tested by following these steps:

* Checkout the branch of [#14800](https://github.com/Yoast/wordpress-seo/pull/14917) and build
* Reset the configuration wizard in the helper
* Go to the yoast SEO dashboard and refresh
* There should be a notification which tells you to start the configuration wizard, click that link
* In the configuration wizard, hit close the wizard
* You will be redirected to the dashboard, where a notification should be saying you didn't finish your wizard
* Reset the configuration wizard in the helper
* Go to the yoast SEO dashboard and refresh
* There should be a notification which tells you to start the configuration wizard, click that link
* In the configuration wizard, go to the last step and hit close 
* Go to the yoast SEO dashboard and refresh
* A notification should be there saying that you completed the wizard
* Reset the configuration wizard in the helper
* Go to the yoast SEO dashboard and refresh
* There should be a notification which tells you to start the configuration wizard