### PR TITLE
Drop table for prominent words

### DIFF
--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -205,10 +205,11 @@ class Yoast_SEO implements WordPress_Plugin {
 		global $wpdb;
 
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.SchemaChange -- We know what we're doing. Really.
-		$wpdb->query( 'DROP TABLE ' . $wpdb->prefix . 'yoast_indexable' );
-		$wpdb->query( 'DROP TABLE ' . $wpdb->prefix . 'yoast_indexable_hierarchy' );
-		$wpdb->query( 'DROP TABLE ' . $wpdb->prefix . 'yoast_migrations' );
-		$wpdb->query( 'DROP TABLE ' . $wpdb->prefix . 'yoast_primary_term' );
+		$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . 'yoast_indexable' );
+		$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . 'yoast_indexable_hierarchy' );
+		$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . 'yoast_migrations' );
+		$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . 'yoast_primary_term' );
+		$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . 'yoast_prominent_words' );
 		// phpcs:enable WordPress.DB.DirectDatabaseQuery.SchemaChange
 
 		\delete_option( 'yoast_migrations_premium' );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Drops the table for prominent words (used by our internal linking functionality, among others) when you drop the indexables tables.

## Relevant technical choices:

* Added `IF EXISTS` checks to all the table drops.

## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

This PR can be tested by following these steps:

* Run the [internal linking feature branch](https://github.com/Yoast/wordpress-seo/tree/feature/internal-linking-phase-2).
* See the `yoast_prominent_words` table gets created, drop it using the button.

Fixes #91 
