### PR TITLE
Add logic to reset the prominent words

### DIFF
--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -139,6 +139,11 @@ class Yoast_SEO implements WordPress_Plugin {
 		global $wpdb;
 
 		$wpdb->delete( $wpdb->prefix . 'postmeta', [ 'meta_key' => '_yst_prominent_words_version' ] );
+
+		$wpdb->query( 'UPDATE ' . $wpdb->prefix . 'yoast_indexable SET prominent_words_version = NULL' );
+		$wpdb->query( 'TRUNCATE TABLE ' . $wpdb->prefix . 'yoast_prominent_words' );
+		WPSEO_Options::set( 'prominent_words_indexation_completed', false );
+		\delete_transient( 'total_unindexed_prominent_words' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Resets the new improved prominent words integration.

## Relevant technical choices:

*

## Milestone

* [ ] I've attached the next release's milestone to this pull request.

## Test instructions

This PR can be tested by following these steps:

* On premium make sure the prominent words are calculated. 
* Press the button to reset the prominent words calculation
* Verify that the prominent words table is emptied and that all prominent_words_version values in the indexables tables are set to null

Fixes #95 
