### PR TITLE
Reset indexables options upon resetting indexables

### DIFF
--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -204,7 +204,7 @@ class Yoast_SEO implements WordPress_Plugin {
 	}
 
 	/**
-	 * Resets the indexables tables, basically deleting them.
+	 * Reset all indexables related tables, options and transients, forcing Yoast SEO to rebuild the tables from scratch and reindex all indexables.
 	 *
 	 * @return bool True if successful, false otherwise.
 	 */
@@ -223,6 +223,13 @@ class Yoast_SEO implements WordPress_Plugin {
 		WPSEO_Options::set( 'indexation_warning_hide_until', false );
 		WPSEO_Options::set( 'indexation_started', false );
 		WPSEO_Options::set( 'indexables_indexation_completed', false );
+
+		// Found in Indexable_Post_Indexation_Action::TRANSIENT_CACHE_KEY.
+		\delete_transient( 'wpseo_total_unindexed_posts' );
+		// Found in Indexable_Post_Type_Archive_Indexation_Action::TRANSIENT_CACHE_KEY.
+		\delete_transient( 'wpseo_total_unindexed_post_type_archives' );
+		// Found in Indexable_Term_Indexation_Action::TRANSIENT_CACHE_KEY.
+		\delete_transient( 'wpseo_total_unindexed_terms' );
 
 		\delete_option( 'yoast_migrations_premium' );
 		return \delete_option( 'yoast_migrations_free' );

--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -219,6 +219,11 @@ class Yoast_SEO implements WordPress_Plugin {
 		$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . 'yoast_prominent_words' );
 		// phpcs:enable WordPress.DB.DirectDatabaseQuery.SchemaChange
 
+		WPSEO_Options::set( 'ignore_indexation_warning', false );
+		WPSEO_Options::set( 'indexation_warning_hide_until', false );
+		WPSEO_Options::set( 'indexation_started', false );
+		WPSEO_Options::set( 'indexables_indexation_completed', false );
+
 		\delete_option( 'yoast_migrations_premium' );
 		return \delete_option( 'yoast_migrations_free' );
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Added resets for indexables related options upon using Yoast Test Helper to reset the indexables and migrations.

## Relevant technical choices:

* Also includes the deletion of transients from https://github.com/Yoast/wordpress-seo/pull/15362.

## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

This PR can be tested by following these steps:

Make sure you are on the 14.5 build of Yoast SEO.

If https://github.com/Yoast/wordpress-seo/pull/15362 hasn't been merged yet, check out that branch instead.

* Make sure all indexables have been indexed under `Yoast SEO` > `Tools`.
* Reset the indexables using this plugin.
* Check that the following options have been set to `false` in the `wpseo` option in the `wp_options` table: `ignore_indexation_warning`, `indexation_warning_hide_until`, `indexation_started`, `indexables_indexation_completed`.
* Check that the following transients **aren't** present in the `wp_options` table:
  * `_transient_wpseo_total_unindexed_posts`
  * `_transient_wpseo_total_unindexed_terms`
  * `_transient_wpseo_total_unindexed_post_type_archives`

* Visit the WordPress dashboard.
* Check that the following transients **are** present in the `wp_options` table:
  * `_transient_wpseo_total_unindexed_posts`
  * `_transient_wpseo_total_unindexed_terms`
  * `_transient_wpseo_total_unindexed_post_type_archives`
* Reset the indexables using this plugin.
* Check that the transients have been deleted.

Fixes #
