### PR TITLE
Travis: change from "trusty" to "xenial"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
+os: linux
 language: php
-dist: trusty
 
 branches:
   only:


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

As the "trusty" environment is no longer officially supported by Travis, let's remove the key which will let the script use the default distro - currently `xenial`.

This updates the Travis config to:
* Removes the global `dist` key, which will let Travis use the default (`xenial`).
* Makes the expected OS explicit (linux).


## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

This PR can be tested by following these steps:

* Verify that the build passes and that the third column in the Travis build page shows `xenial` not `trusty`

