### PR TITLE
Add a checkbox for the structured data feature flag

### DIFF
--- a/src/form-presenter.php
+++ b/src/form-presenter.php
@@ -36,7 +36,7 @@ class Form_Presenter {
 	}
 
 	/**
-	 * Build a checkbox element.
+	 * Builds a checkbox element.
 	 *
 	 * @param string $option  The option to make a checkbox for.
 	 * @param string $label   The label for the checkbox.
@@ -53,7 +53,7 @@ class Form_Presenter {
 	}
 
 	/**
-	 * Build a select element.
+	 * Builds a select element.
 	 *
 	 * @param string   $option   The option to make a checkbox for.
 	 * @param string   $label    The label for the checkbox.

--- a/src/schema.php
+++ b/src/schema.php
@@ -122,7 +122,7 @@ class Schema implements Integration {
 	}
 
 	/**
-	 * Make sure we only store data we know how to deal with.
+	 * Makes sure we only store data we know how to deal with.
 	 *
 	 * @param string $value The submitted value.
 	 *
@@ -180,7 +180,7 @@ class Schema implements Integration {
 	}
 
 	/**
-	 * Deep replace strings in array.
+	 * Deep replaces strings in array.
 	 *
 	 * @param string $needle      The needle to replace.
 	 * @param string $replacement The replacement.

--- a/src/schema.php
+++ b/src/schema.php
@@ -158,6 +158,10 @@ class Schema implements Integration {
 	 * Enables the feature flag for the structured data blocks.
 	 */
 	public function enable_feature_flag() {
+		if ( \defined( 'YOAST_SEO_SCHEMA_BLOCKS' ) ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- The prefix matches that of Yoast SEO, where this flag belongs.
+			return;
+		}
+
 		\define( 'YOAST_SEO_SCHEMA_BLOCKS', true ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- The prefix matches that of Yoast SEO, where this flag belongs.
 	}
 

--- a/src/schema.php
+++ b/src/schema.php
@@ -5,7 +5,7 @@ namespace Yoast\WP\Test_Helper;
 use WPSEO_Utils;
 
 /**
- * Class to manage registering and rendering the admin page in WordPress.
+ * Class to influence the Schema functionality of Yoast SEO (Premium).
  */
 class Schema implements Integration {
 
@@ -31,6 +31,10 @@ class Schema implements Integration {
 	public function add_hooks() {
 		if ( $this->option->get( 'replace_schema_domain' ) === true ) {
 			\add_filter( 'wpseo_debug_json_data', [ $this, 'replace_domain' ] );
+		}
+
+		if ( $this->option->get( 'enable_structured_data_blocks' ) === true ) {
+			\add_filter( 'wpseo_debug_json_data', [ $this, 'enable_feature_flag' ] );
 		}
 
 		switch ( $this->option->get( 'is_needed_breadcrumb' ) ) {
@@ -68,6 +72,12 @@ class Schema implements Integration {
 			$this->option->get( 'replace_schema_domain' )
 		);
 
+		$output .= Form_Presenter::create_checkbox(
+			'enable_structured_data_blocks',
+			'Enable the feature flag for the structured data blocks.',
+			$this->option->get( 'enable_structured_data_blocks' )
+		);
+
 		$select_options = [
 			'none' => 'Don\'t influence',
 			'show' => 'Always include',
@@ -99,6 +109,7 @@ class Schema implements Integration {
 	public function handle_submit() {
 		if ( \check_admin_referer( 'yoast_seo_test_schema' ) !== false ) {
 			$this->option->set( 'replace_schema_domain', isset( $_POST['replace_schema_domain'] ) );
+			$this->option->set( 'enable_structured_data_blocks', isset( $_POST['enable_structured_data_blocks'] ) );
 		}
 
 		$is_needed_breadcrumb = $this->validate_submit( \filter_input( \INPUT_POST, 'is_needed_breadcrumb' ) );
@@ -141,6 +152,13 @@ class Schema implements Integration {
 		}
 
 		return $this->array_value_str_replace( $source, $target, $data );
+	}
+
+	/**
+	 * Enables the feature flag for the structured data blocks.
+	 */
+	public function enable_feature_flag() {
+		define( 'YOAST_SEO_SCHEMA_BLOCKS', true );
 	}
 
 	/**

--- a/src/schema.php
+++ b/src/schema.php
@@ -34,7 +34,7 @@ class Schema implements Integration {
 		}
 
 		if ( $this->option->get( 'enable_structured_data_blocks' ) === true ) {
-			\add_filter( 'wpseo_debug_json_data', [ $this, 'enable_feature_flag' ] );
+			\add_filter( 'init', [ $this, 'enable_feature_flag' ] );
 		}
 
 		switch ( $this->option->get( 'is_needed_breadcrumb' ) ) {

--- a/src/schema.php
+++ b/src/schema.php
@@ -158,7 +158,7 @@ class Schema implements Integration {
 	 * Enables the feature flag for the structured data blocks.
 	 */
 	public function enable_feature_flag() {
-		define( 'YOAST_SEO_SCHEMA_BLOCKS', true );
+		\define( 'YOAST_SEO_SCHEMA_BLOCKS', true ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- The prefix matches that of Yoast SEO, where this flag belongs.
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds a checkbox to set and unset the feature flag for the structured data blocks.

## Relevant technical choices:

* I basically copied the implementation from the other checkbox in the Schema section of the Test Helper ("Replace .test domain name with example.com in Schema output.").
* This explains why `wpseo_debug_json_data` is the filter that I'm hooking into.

## Milestone

* [ ] I've attached the next release's milestone to this pull request.

## Test instructions

This PR can be tested by following these steps:

* Open the Test Helper.
* In the Schema section, see a checkbox: "Enable the feature flag for the structured data blocks.".
* Check the box and save.
* In your database, in `wp_options`, in `yoast_test_helper`, see that `enable_structured_data_blocks` has been set to `1`.
* As long as [the PR](https://yoast.atlassian.net/browse/P2-342) that implements the feature flag in Free has not been merged, you can test whether the feature flag has been set by pasting `var_dump( \defined( 'YOAST_SEO_SCHEMA_BLOCKS') ); die;` in the `enable_feature_flag` method, after the line where the feature flag is defined. It should print `true` when you check the box and save, and also when the box has already been checked and you refresh the Test Helper.
* Once the feature flag PR has been merged, you can test whether the feature flag has been set by seeing any structured data blocks functionality that will have been implemented by that point.
* Uncheck the box and save.
* See that `enable_structured_data_blocks` has been set to `0` in the database.

Fixes https://yoast.atlassian.net/browse/P2-353
