### PR TITLE
Fix resetting the link counter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoast-test-helper",
-  "version": "1.8",
+  "version": "1.9",
   "description": "A plugin to aid in testing and developing the Yoast SEO plugin and its extensions.",
   "repository": "https://github.com/Yoast/yoast-test-helper.git",
   "author": "Yoast",
@@ -19,6 +19,6 @@
   },
   "dependencies": {},
   "yoast": {
-    "pluginVersion": "1.8"
+    "pluginVersion": "1.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoast-test-helper",
-  "version": "1.9",
+  "version": "1.9-RC1",
   "description": "A plugin to aid in testing and developing the Yoast SEO plugin and its extensions.",
   "repository": "https://github.com/Yoast/yoast-test-helper.git",
   "author": "Yoast",
@@ -19,6 +19,6 @@
   },
   "dependencies": {},
   "yoast": {
-    "pluginVersion": "1.9"
+    "pluginVersion": "1.9-RC1"
   }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -39,7 +39,7 @@ If you find bugs or would like to contribute, see our [GitHub repo](https://gith
 
 Bugfixes:
 
-* Fixes a bug where the old links table is resetted resulting in the link columns not being emptied.
+* Fixes a bug where the old links table is reset resulting in the link columns not being emptied.
 * Fixes a bug where the links could be attached to the wrong indexables when resetting the indexable tables and migrations.
 
 = 1.8 =

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: yoast, joostdevalk, omarreiss, jipmoors, herregroen
 Tags: Yoast, Yoast SEO, development
 Requires at least: 5.4
 Tested up to: 5.5
-Stable tag: 1.9
+Stable tag: 1.8
 Requires PHP: 5.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: yoast, joostdevalk, omarreiss, jipmoors, herregroen
 Tags: Yoast, Yoast SEO, development
 Requires at least: 5.4
 Tested up to: 5.5
-Stable tag: 1.8
+Stable tag: 1.9
 Requires PHP: 5.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -34,6 +34,13 @@ If you find bugs or would like to contribute, see our [GitHub repo](https://gith
 1. Screenshot of the Yoast test helper admin page.
 
 == Changelog ==
+
+= 1.9 =
+
+Bugfixes:
+
+* Fixes a bug where the old links table is resetted resulting in the link columns not being emptied.
+* Fixes a bug where the links could be attached to the wrong indexables when resetting the indexable tables and migrations.
 
 = 1.8 =
 

--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -217,6 +217,8 @@ class Yoast_SEO implements WordPress_Plugin {
 		$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . 'yoast_migrations' );
 		$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . 'yoast_primary_term' );
 		$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . 'yoast_prominent_words' );
+		$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . 'yoast_seo_links' );
+
 		// phpcs:enable WordPress.DB.DirectDatabaseQuery.SchemaChange
 
 		WPSEO_Options::set( 'ignore_indexation_warning', false );

--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -127,7 +127,10 @@ class Yoast_SEO implements WordPress_Plugin {
 	private function reset_internal_link_count() {
 		global $wpdb;
 
-		$wpdb->query( 'UPDATE ' . $wpdb->prefix . 'yoast_seo_meta SET internal_link_count = NULL' );
+		$wpdb->query( 'UPDATE ' . $wpdb->prefix . 'yoast_indexable SET link_count = NULL, incoming_link_count = NULL' );
+
+		delete_transient( 'wpseo_unindexed_post_link_count' );
+		delete_transient( 'wpseo_unindexed_term_link_count' );
 	}
 
 	/**

--- a/yoast-test-helper.php
+++ b/yoast-test-helper.php
@@ -8,7 +8,7 @@
  *
  * @wordpress-plugin
  * Plugin Name: Yoast Test Helper
- * Version:     1.9
+ * Version:     1.9-RC1
  * Plugin URI:  https://github.com/yoast/yoast-test-helper
  * Description: Utility to provide testing features for Yoast plugins.
  * Author:      Team Yoast
@@ -33,7 +33,7 @@
 
 define( 'YOAST_TEST_HELPER_FILE', __FILE__ );
 define( 'YOAST_TEST_HELPER_DIR', dirname( YOAST_TEST_HELPER_FILE ) );
-define( 'YOAST_TEST_HELPER_VERSION', '1.9' );
+define( 'YOAST_TEST_HELPER_VERSION', '1.9-RC1' );
 
 if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	require __DIR__ . '/vendor/autoload.php';

--- a/yoast-test-helper.php
+++ b/yoast-test-helper.php
@@ -8,7 +8,7 @@
  *
  * @wordpress-plugin
  * Plugin Name: Yoast Test Helper
- * Version:     1.8
+ * Version:     1.9
  * Plugin URI:  https://github.com/yoast/yoast-test-helper
  * Description: Utility to provide testing features for Yoast plugins.
  * Author:      Team Yoast
@@ -33,7 +33,7 @@
 
 define( 'YOAST_TEST_HELPER_FILE', __FILE__ );
 define( 'YOAST_TEST_HELPER_DIR', dirname( YOAST_TEST_HELPER_FILE ) );
-define( 'YOAST_TEST_HELPER_VERSION', '1.8' );
+define( 'YOAST_TEST_HELPER_VERSION', '1.9' );
 
 if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	require __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the old links table is reset resulting in the link columns not being emptied.
* Fixes a bug where the links could be attached to the wrong indexables when resetting the indexable tables and migrations.

## Relevant technical choices:

* Chosen to also remove the links table because it is coupled with the indexables and thus is more or less an indexables feature.

## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

ZIP file of 1.9-RC1 for testing:
[yoast-test-helper-1.9-RC1.zip](https://github.com/Yoast/yoast-test-helper/files/5312044/yoast-test-helper-1.9-RC1.zip)


This PR can be tested by following these steps:

* Have everything indexed.
* Reset the link counts and see in the post overview that the link counts are resetted.
* Have the links calculated and make sure the `wp_yoast_seo_links` table have some rows
* Reset the indexables & migrations and see that the table is truncated (no records present)

Fixes #
