### PR TITLE
Travis: lint files against PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ jobs:
       env: PHPLINT=1 PHPCS=1 SECURITY=1
     - php: 5.6
       env: PHPLINT=1
+    - php: "nightly"
+      env: PHPLINT=1
     - stage: deploy
       if: tag IS present
       before_deploy:
@@ -31,7 +33,6 @@ jobs:
         - eval $(ssh-agent -s)
         - ssh-add ./deploy_keys/travis_dist_id_rsa
 
-
        # If the commit was tagged, create an artifact and push it to the distribution github
       deploy:
         skip_cleanup: true
@@ -41,6 +42,10 @@ jobs:
           tags: true
           repo: $TRAVIS_REPO_SLUG
           all_branches: true
+
+  allow_failures:
+    # Allow failures for unstable builds.
+    - php: "nightly"
 
 cache:
   directories:


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Prepare for the release of PHP 8

## Relevant technical choices:

While this plugin doesn't have any (unit) tests, let's at least lint the plugin files against PHP 8.


## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

This PR can be tested by following these steps:

* Check the output of the Travis build for the PR.
