### PR TITLE
Remove cron job when resetting indexables

### DIFF
--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -225,6 +225,7 @@ class Yoast_SEO implements WordPress_Plugin {
 		WPSEO_Options::set( 'indexation_warning_hide_until', false );
 		WPSEO_Options::set( 'indexation_started', false );
 		WPSEO_Options::set( 'indexables_indexation_completed', false );
+		WPSEO_Options::set( 'indexing_first_time', true );
 
 		// Found in Indexing_Notification_Integration::NOTIFICATION_ID.
 		\wp_clear_scheduled_hook( 'wpseo-reindex' );

--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -226,6 +226,9 @@ class Yoast_SEO implements WordPress_Plugin {
 		WPSEO_Options::set( 'indexation_started', false );
 		WPSEO_Options::set( 'indexables_indexation_completed', false );
 
+		// Found in Indexing_Notification_Integration::NOTIFICATION_ID
+		\wp_clear_scheduled_hook( 'wpseo-reindex' );
+
 		// Found in Indexable_Post_Indexation_Action::TRANSIENT_CACHE_KEY.
 		\delete_transient( 'wpseo_total_unindexed_posts' );
 		// Found in Indexable_Post_Type_Archive_Indexation_Action::TRANSIENT_CACHE_KEY.

--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -226,7 +226,7 @@ class Yoast_SEO implements WordPress_Plugin {
 		WPSEO_Options::set( 'indexation_started', false );
 		WPSEO_Options::set( 'indexables_indexation_completed', false );
 
-		// Found in Indexing_Notification_Integration::NOTIFICATION_ID
+		// Found in Indexing_Notification_Integration::NOTIFICATION_ID.
 		\wp_clear_scheduled_hook( 'wpseo-reindex' );
 
 		// Found in Indexable_Post_Indexation_Action::TRANSIENT_CACHE_KEY.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Removes a cron-job that checks the indexables daily when resetting the indexables.
* Resets the `indexing_first_time` option when resetting the indexables.

## Relevant technical choices:

*

## Milestone

* [ ] I've attached the next release's milestone to this pull request.

## Test instructions

This PR can be tested by following these steps:

* Run the indexation on the Yoast -> Tools page.
* Reset the indexables.
* Make sure the `Start SEO Data optimization` button is back.

Fixes #
