### PR TITLE
Show a notification when resetting the indexable tables, prominent words or internal link count.

### DIFF
--- a/src/indexing-reason-integration.php
+++ b/src/indexing-reason-integration.php
@@ -6,7 +6,7 @@ namespace Yoast\WP\Test_Helper;
 /**
  * Adds a filter to change the alert based on the saved set indexing reason.
  */
-class Indexing_Reason implements Integration {
+class Indexing_Reason_Integration implements Integration {
 
 	/**
 	 * Registers the hook to set the indexing reason.

--- a/src/indexing-reason-integration.php
+++ b/src/indexing-reason-integration.php
@@ -2,7 +2,6 @@
 
 namespace Yoast\WP\Test_Helper;
 
-
 /**
  * Adds a filter to change the alert based on the saved set indexing reason.
  */
@@ -23,7 +22,7 @@ class Indexing_Reason_Integration implements Integration {
 	 *
 	 * @return string The reason to show.
 	 */
-	public function set_indexing_alert( $alert, $reason  ) {
+	public function set_indexing_alert( $alert, $reason ) {
 		if ( $reason !== 'indexables-reset-by-test-helper' ) {
 			return $alert;
 		}

--- a/src/indexing-reason.php
+++ b/src/indexing-reason.php
@@ -29,7 +29,7 @@ class Indexing_Reason implements Integration {
 		}
 
 		return sprintf(
-			\esc_html( 'Because of hard reset in the %1$s, some of your SEO data needs to be reprocessed.' ),
+			\esc_html( 'Because some of your SEO data was reset by the %1$s, your SEO data needs to be reprocessed.' ),
 			'Yoast Test Helper'
 		);
 	}

--- a/src/indexing-reason.php
+++ b/src/indexing-reason.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Yoast\WP\Test_Helper;
+
+
+/**
+ * Adds a filter to change the alert based on the saved set indexing reason.
+ */
+class Indexing_Reason implements Integration {
+
+	/**
+	 * Registers the hook to set the indexing reason.
+	 */
+	public function add_hooks() {
+		\add_filter( 'wpseo_indexables_indexation_alert', [ $this, 'set_indexing_alert' ], 10, 2 );
+	}
+
+	/**
+	 * Sets the indexing alert to something more specific when the reason is an indexables reset.
+	 *
+	 * @param string $alert  The current content of alert.
+	 * @param string $reason The reason to show the alert for.
+	 *
+	 * @return string The reason to show.
+	 */
+	public function set_indexing_alert( $alert, $reason  ) {
+		if ( $reason !== 'indexables-reset' ) {
+			return $alert;
+		}
+
+		return sprintf(
+			\esc_html( 'Because of hard reset in the %1$s, some of your SEO data needs to be reprocessed.' ),
+			'Yoast Test Helper'
+		);
+	}
+}

--- a/src/indexing-reason.php
+++ b/src/indexing-reason.php
@@ -24,7 +24,7 @@ class Indexing_Reason implements Integration {
 	 * @return string The reason to show.
 	 */
 	public function set_indexing_alert( $alert, $reason  ) {
-		if ( $reason !== 'indexables-reset' ) {
+		if ( $reason !== 'indexables-reset-by-test-helper' ) {
 			return $alert;
 		}
 

--- a/src/plugin.php
+++ b/src/plugin.php
@@ -89,7 +89,7 @@ class Plugin implements Integration {
 		$this->integrations[] = new Domain_Dropdown( $option );
 		$this->integrations[] = new Inline_Script( $option );
 		$this->integrations[] = new Admin_Debug_Info( $option );
-		$this->integrations[] = new Indexing_Reason();
+		$this->integrations[] = new Indexing_Reason_Integration();
 	}
 
 	/**

--- a/src/plugin.php
+++ b/src/plugin.php
@@ -89,6 +89,7 @@ class Plugin implements Integration {
 		$this->integrations[] = new Domain_Dropdown( $option );
 		$this->integrations[] = new Inline_Script( $option );
 		$this->integrations[] = new Admin_Debug_Info( $option );
+		$this->integrations[] = new Indexing_Reason();
 	}
 
 	/**

--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -134,7 +134,7 @@ class Yoast_SEO implements WordPress_Plugin {
 		delete_transient( 'wpseo_unindexed_post_link_count' );
 		delete_transient( 'wpseo_unindexed_term_link_count' );
 
-		$this->reset_indexing_notification( 'indexables-reset' );
+		$this->reset_indexing_notification( 'indexables-reset-by-test-helper' );
 	}
 
 	/**
@@ -152,7 +152,7 @@ class Yoast_SEO implements WordPress_Plugin {
 		WPSEO_Options::set( 'prominent_words_indexation_completed', false );
 		\delete_transient( 'total_unindexed_prominent_words' );
 
-		$this->reset_indexing_notification( 'indexables-reset' );
+		$this->reset_indexing_notification( 'indexables-reset-by-test-helper' );
 	}
 
 	/**
@@ -233,7 +233,7 @@ class Yoast_SEO implements WordPress_Plugin {
 		WPSEO_Options::set( 'indexables_indexation_completed', false );
 		WPSEO_Options::set( 'indexing_first_time', true );
 
-		$this->reset_indexing_notification( 'indexables-reset' );
+		$this->reset_indexing_notification( 'indexables-reset-by-test-helper' );
 
 		// Found in Indexable_Post_Indexation_Action::TRANSIENT_CACHE_KEY.
 		\delete_transient( 'wpseo_total_unindexed_posts' );

--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\Test_Helper\WordPress_Plugins;
 
 use WPSEO_Options;
+use Yoast\WP\SEO\Integrations\Admin\Indexing_Notification_Integration;
 use Yoast_Notification_Center;
 
 /**
@@ -250,8 +251,7 @@ class Yoast_SEO implements WordPress_Plugin {
 	 *
 	 * @param string $reason The indexing reason why the site needs to be reindexed.
 	 */
-	private function reset_indexing_notification( $reason ) {
-		WPSEO_Options::set( 'indexing_reason', $reason );
-		Yoast_Notification_Center::get()->remove_notification_by_id( 'wpseo-reindex' );
+	protected function reset_indexing_notification( $reason ) {
+		YoastSEO()->helpers->indexing->set_reason( $reason );
 	}
 }

--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\Test_Helper\WordPress_Plugins;
 
 use WPSEO_Options;
+use Yoast_Notification_Center;
 
 /**
  * Class to represent Yoast SEO.
@@ -131,6 +132,8 @@ class Yoast_SEO implements WordPress_Plugin {
 
 		delete_transient( 'wpseo_unindexed_post_link_count' );
 		delete_transient( 'wpseo_unindexed_term_link_count' );
+
+		$this->reset_indexing_notification( 'indexables-reset' );
 	}
 
 	/**
@@ -147,6 +150,8 @@ class Yoast_SEO implements WordPress_Plugin {
 		$wpdb->query( 'TRUNCATE TABLE ' . $wpdb->prefix . 'yoast_prominent_words' );
 		WPSEO_Options::set( 'prominent_words_indexation_completed', false );
 		\delete_transient( 'total_unindexed_prominent_words' );
+
+		$this->reset_indexing_notification( 'indexables-reset' );
 	}
 
 	/**
@@ -227,8 +232,7 @@ class Yoast_SEO implements WordPress_Plugin {
 		WPSEO_Options::set( 'indexables_indexation_completed', false );
 		WPSEO_Options::set( 'indexing_first_time', true );
 
-		// Found in Indexing_Notification_Integration::NOTIFICATION_ID.
-		\wp_clear_scheduled_hook( 'wpseo-reindex' );
+		$this->reset_indexing_notification( 'indexables-reset' );
 
 		// Found in Indexable_Post_Indexation_Action::TRANSIENT_CACHE_KEY.
 		\delete_transient( 'wpseo_total_unindexed_posts' );
@@ -239,5 +243,15 @@ class Yoast_SEO implements WordPress_Plugin {
 
 		\delete_option( 'yoast_migrations_premium' );
 		return \delete_option( 'yoast_migrations_free' );
+	}
+
+	/**
+	 * Resets the indexing notification such that it is shown again.
+	 *
+	 * @param string $reason The indexing reason why the site needs to be reindexed.
+	 */
+	private function reset_indexing_notification( $reason ) {
+		WPSEO_Options::set( 'indexing_reason', $reason );
+		Yoast_Notification_Center::get()->remove_notification_by_id( 'wpseo-reindex' );
 	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where no notification is shown to reindex your site when resetting the indexables tables and migrations.
* Fixes a bug where no notification is shown to reindex your site when resetting the prominent words table.
* Fixes a bug where no notification is shown to reindex your site when resetting the internal link count.

## Relevant technical choices:

* 

## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

This PR can be tested by following these steps:

### When resetting the indexables table
* Make sure that the Yoast Free or Premium plugin is activated.
* Make sure that your site is fully indexed.
* Reset the indexables table and migrations using the test helper.
* You should get a new notification in the Yoast SEO dashboard to reindex your site.

### When resetting the internal link count
* Make sure that the Yoast Free or Premium plugin is activated.
* Make sure that your site is fully indexed.
* Reset the internal link count using the test helper.
* You should get a new notification in the Yoast SEO dashboard to reindex your site.

### When resetting the prominent words table
* Make sure that the Yoast **Premium** plugin is activated.
  * This needs to be tested with an activated Premium plugin, since this resets a Premium specific feature.
* Make sure that your site is fully indexed.
* Reset the prominent words calculation using the test helper.
* You should get a new notification in the Yoast SEO dashboard to reindex your site.

Fixes #
