### PR TITLE
Rename options and remove old ones

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ cache:
     - $HOME/.composer/cache
 
 before_install:
+- composer self-update 1.10.16
 - if [[ "$COVERAGE" != "1" ]]; then phpenv config-rm xdebug.ini || echo 'No xdebug config.'; fi
 - export SECURITYCHECK_DIR=/tmp/security-checker
 

--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -221,8 +221,6 @@ class Yoast_SEO implements WordPress_Plugin {
 
 		// phpcs:enable WordPress.DB.DirectDatabaseQuery.SchemaChange
 
-		WPSEO_Options::set( 'ignore_indexation_warning', false );
-		WPSEO_Options::set( 'indexation_warning_hide_until', false );
 		WPSEO_Options::set( 'indexation_started', false );
 		WPSEO_Options::set( 'indexables_indexation_completed', false );
 		WPSEO_Options::set( 'indexing_first_time', true );

--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -221,8 +221,8 @@ class Yoast_SEO implements WordPress_Plugin {
 
 		// phpcs:enable WordPress.DB.DirectDatabaseQuery.SchemaChange
 
-		WPSEO_Options::set( 'indexation_started', false );
-		WPSEO_Options::set( 'indexables_indexation_completed', false );
+		WPSEO_Options::set( 'indexing_started', false );
+		WPSEO_Options::set( 'indexables_indexing_completed', false );
 		WPSEO_Options::set( 'indexing_first_time', true );
 
 		// Found in Indexing_Notification_Integration::NOTIFICATION_ID.

--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -145,7 +145,7 @@ class Yoast_SEO implements WordPress_Plugin {
 
 		$wpdb->query( 'UPDATE ' . $wpdb->prefix . 'yoast_indexable SET prominent_words_version = NULL' );
 		$wpdb->query( 'TRUNCATE TABLE ' . $wpdb->prefix . 'yoast_prominent_words' );
-		WPSEO_Options::set( 'prominent_words_indexation_completed', false );
+		WPSEO_Options::set( 'prominent_words_indexing_completed', false );
 		\delete_transient( 'total_unindexed_prominent_words' );
 	}
 

--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -221,7 +221,7 @@ class Yoast_SEO implements WordPress_Plugin {
 
 		// phpcs:enable WordPress.DB.DirectDatabaseQuery.SchemaChange
 
-		WPSEO_Options::set( 'indexing_started', false );
+		WPSEO_Options::set( 'indexing_started', null );
 		WPSEO_Options::set( 'indexables_indexing_completed', false );
 		WPSEO_Options::set( 'indexing_first_time', true );
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Uses the new option name for resetting these options, and removes the setting of two other options which are no longer used.

## Relevant technical choices:

* This PR accompanies https://github.com/Yoast/wordpress-seo/pull/16239.
* When this PR has been merged, the Test Helper will require Yoast SEO 15.3 (or higher) for the indexable resetting functionality to work.

## Milestone

* [ ] I've attached the next release's milestone to this pull request.

## Test instructions

This PR can be tested by following these steps:

**Test setting the Free options**
* Activate Free.
* Make sure that Yoast SEO has the code from https://github.com/Yoast/wordpress-seo/pull/16239.
* Run the indexing process on the Yoast Tools page (if you hadn't already).
* Reset the indexables in the test helper.
* In your database, in `wp_options` --> `wpseo`, see the following key-value pairs:
    * `'indexing_started', false`
    * `'indexables_indexing_completed', false`
    * `'indexing_first_time', true`

**Test setting the Premium options**
* Activate Premium.
* Make sure it has the code from https://github.com/Yoast/wordpress-seo-premium/pull/3058.
* Run the indexing process on the Yoast Tools page (if you hadn't already).
* Reset the prominent words in the test helper.
* In your database, in `wp_options` --> `wpseo_premium`, see the following key-value pair:
    * `'prominent_words_indexing_completed, 0`.

Fixes https://yoast.atlassian.net/browse/P2-411
