### PR TITLE
Composer: update YoastCS to v 2.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "php": "^5.6.20 || ^7.0"
   },
   "require-dev": {
-    "yoast/yoastcs": "^2.0.2",
+    "yoast/yoastcs": "^2.1.0",
     "php-parallel-lint/php-parallel-lint": "^1.2",
     "php-parallel-lint/php-console-highlighter": "^0.5"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,27 +4,27 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3ee2e9c6babe095c703d659aae1aeb60",
+    "content-hash": "74f59b200a33754b93098564223e42dd",
     "packages": [],
     "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.6.2",
+            "version": "v0.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "8001af8eb107fbfcedc31a8b51e20b07d85b457a"
+                "reference": "e8d808670b8f882188368faaf1144448c169c0b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/8001af8eb107fbfcedc31a8b51e20b07d85b457a",
-                "reference": "8001af8eb107fbfcedc31a8b51e20b07d85b457a",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/e8d808670b8f882188368faaf1144448c169c0b7",
+                "reference": "e8d808670b8f882188368faaf1144448c169c0b7",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0",
-                "php": "^5.3|^7",
-                "squizlabs/php_codesniffer": "^2|^3"
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2 || ^3 || 4.0.x-dev"
             },
             "require-dev": {
                 "composer/composer": "*",
@@ -71,7 +71,7 @@
                 "stylecheck",
                 "tests"
             ],
-            "time": "2020-01-29T20:22:20+00:00"
+            "time": "2020-06-25T14:57:39+00:00"
         },
         {
             "name": "php-parallel-lint/php-console-color",
@@ -382,16 +382,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.5",
+            "version": "3.5.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6"
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
-                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9d583721a7157ee997f235f327de038e7ea6dac4",
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4",
                 "shasum": ""
             },
             "require": {
@@ -429,7 +429,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2020-04-17T01:09:41+00:00"
+            "time": "2020-10-23T02:01:07+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -479,28 +479,28 @@
         },
         {
             "name": "yoast/yoastcs",
-            "version": "2.0.2",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/yoastcs.git",
-                "reference": "0f6d2a18545e4b0751d7966a61f0cfc95a9f8d72"
+                "reference": "8cc5cb79b950588f05a45d68c3849ccfcfef6298"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/yoastcs/zipball/0f6d2a18545e4b0751d7966a61f0cfc95a9f8d72",
-                "reference": "0f6d2a18545e4b0751d7966a61f0cfc95a9f8d72",
+                "url": "https://api.github.com/repos/Yoast/yoastcs/zipball/8cc5cb79b950588f05a45d68c3849ccfcfef6298",
+                "reference": "8cc5cb79b950588f05a45d68c3849ccfcfef6298",
                 "shasum": ""
             },
             "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6.2 || ^0.7",
                 "php": ">=5.4",
                 "phpcompatibility/phpcompatibility-wp": "^2.1.0",
                 "squizlabs/php_codesniffer": "^3.5.0",
                 "wp-coding-standards/wpcs": "^2.2.0"
             },
             "require-dev": {
-                "jakub-onderka/php-console-highlighter": "^0.4",
-                "jakub-onderka/php-parallel-lint": "^1.0",
+                "php-parallel-lint/php-console-highlighter": "^0.5",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpcompatibility/php-compatibility": "^9.2.0",
                 "phpcsstandards/phpcsdevtools": "^1.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
@@ -526,7 +526,7 @@
                 "wordpress",
                 "yoast"
             ],
-            "time": "2020-04-02T17:16:18+00:00"
+            "time": "2020-10-27T09:51:49+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Updated dev dependencies

## Relevant technical choices:

* Updated YoastCS from `2.0.2` to `2.1.0`.
* Updated PHP_CodeSniffer from `3.5.5` to `3.5.8`.
* Updated the DealerDirect Composer plugin from `0.6.2` to `0.7.0` (which is compatible with Composer 2.0).

Relevant changes in YoastCS:
* The minimum supported WP version has changed to `5.4`.
* A new check for test doubles being named as such.
* A few bugfixes.
* Various sniffs now provide metrics.

Relevant changes in PHPCS:
* PHPCS will now _run_ without problems on PHP 8.
    Note: it will not necessarily handle all code using PHP 8 syntax correctly yet, though it does contain preliminary support for various syntaxes.
* Lots of bugfixes.

Refs:
* https://github.com/Yoast/yoastcs/releases/tag/2.1.0
* https://github.com/squizlabs/php_codesniffer/releases


## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

This PR can be tested by following these steps:

* _N/A_

Fixes _build failures when Composer 2.0 is used_.
