### PR TITLE
Make reset functionality more robust

### DIFF
--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -131,8 +131,8 @@ class Yoast_SEO implements WordPress_Plugin {
 
 		$wpdb->query( 'UPDATE ' . $wpdb->prefix . 'yoast_indexable SET link_count = NULL, incoming_link_count = NULL' );
 
-		delete_transient( 'wpseo_unindexed_post_link_count' );
-		delete_transient( 'wpseo_unindexed_term_link_count' );
+		\delete_transient( 'wpseo_unindexed_post_link_count' );
+		\delete_transient( 'wpseo_unindexed_term_link_count' );
 
 		$this->reset_indexing_notification( 'indexables-reset-by-test-helper' );
 	}

--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -130,6 +130,7 @@ class Yoast_SEO implements WordPress_Plugin {
 		global $wpdb;
 
 		$wpdb->query( 'UPDATE ' . $wpdb->prefix . 'yoast_indexable SET link_count = NULL, incoming_link_count = NULL' );
+		$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . 'yoast_seo_links' );
 
 		\delete_transient( 'wpseo_unindexed_post_link_count' );
 		\delete_transient( 'wpseo_unindexed_term_link_count' );

--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -218,13 +218,17 @@ class Yoast_SEO implements WordPress_Plugin {
 	private function reset_indexables() {
 		global $wpdb;
 
+		// Reset the prominent words calculation.
+		$this->reset_prominent_words_calculation();
+
+		// Reset the internal link count.
+		$this->reset_internal_link_count();
+
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.SchemaChange -- We know what we're doing. Really.
 		$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . 'yoast_indexable' );
 		$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . 'yoast_indexable_hierarchy' );
 		$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . 'yoast_migrations' );
 		$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . 'yoast_primary_term' );
-		$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . 'yoast_prominent_words' );
-		$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . 'yoast_seo_links' );
 
 		// phpcs:enable WordPress.DB.DirectDatabaseQuery.SchemaChange
 

--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -130,8 +130,6 @@ class Yoast_SEO implements WordPress_Plugin {
 		global $wpdb;
 
 		$wpdb->query( 'UPDATE ' . $wpdb->prefix . 'yoast_indexable SET link_count = NULL, incoming_link_count = NULL' );
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.SchemaChange -- We know what we're doing. Really.
-		$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . 'yoast_seo_links' );
 
 		\delete_transient( 'wpseo_unindexed_post_link_count' );
 		\delete_transient( 'wpseo_unindexed_term_link_count' );
@@ -230,6 +228,7 @@ class Yoast_SEO implements WordPress_Plugin {
 		$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . 'yoast_indexable_hierarchy' );
 		$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . 'yoast_migrations' );
 		$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . 'yoast_primary_term' );
+		$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . 'yoast_seo_links' );
 
 		// phpcs:enable WordPress.DB.DirectDatabaseQuery.SchemaChange
 

--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -130,6 +130,7 @@ class Yoast_SEO implements WordPress_Plugin {
 		global $wpdb;
 
 		$wpdb->query( 'UPDATE ' . $wpdb->prefix . 'yoast_indexable SET link_count = NULL, incoming_link_count = NULL' );
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.SchemaChange -- We know what we're doing. Really.
 		$wpdb->query( 'DROP TABLE IF EXISTS ' . $wpdb->prefix . 'yoast_seo_links' );
 
 		\delete_transient( 'wpseo_unindexed_post_link_count' );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the `Reset indexables tables & migrations` functionality did not reset the internal link count transients.

## Relevant technical choices:

* The `reset_indexables` method is meant to reset everything, including the internal link count and the prominent words calculation. However, `reset_indexables` was incomplete. For example, it didn't reset the transients related to the internal link count (`wpseo_unindexed_post_link_count` and `wpseo_unindexed_term_link_count`) and related to the prominent words calculation (`total_unindexed_prominent_words`). I decided to call `reset_prominent_words_calculation` and `reset_internal_link_count` from within `reset_indexables`, so that I didn't have to duplicate their code.

## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure your site is fully indexed.
* Run the indexables tables & migrations reset.
* See the tables have been emptied and the indexing notification is shown.
* Please also test in Premium to make sure the prominent words table is emptied correctly when resetting the indexables.

FYI, you cannot easily see whether the `wpseo_unindexed_post_link_count` and `wpseo_unindexed_term_link_count` transients have indeed been deleted. This is because they are immediately set again when the `admin_init` hook fires, which triggers `maybe_create_notification`, which in turn sets these transients. But if you see that the internal link count table has been emptied, you know that the code that deletes the transients has also been executed.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

Fixes #
