### PR TITLE
Change the Host header along with the host in the url

### DIFF
--- a/src/domain-dropdown.php
+++ b/src/domain-dropdown.php
@@ -116,9 +116,10 @@ class Domain_Dropdown implements Integration {
 	private function replace_domain( $domain, $url, $headers ) {
 		$host     = '';
 		$url_host = \wp_parse_url( $url, \PHP_URL_HOST );
+		$new_host = \wp_parse_url( $domain, \PHP_URL_HOST );
 
 		if ( $url_host === 'my.yoast.com' ) {
-			$host = isset( $headers['Host'] ) ? $headers['Host'] : $url_host;
+			$host = isset( $headers['Host'] ) ? $headers['Host'] : $new_host;
 			$url  = \str_replace( 'https://' . $url_host, $domain, $url );
 		}
 


### PR DESCRIPTION
If the Host header remains "my.yoast.com", the request will go to the live servers even though the url says staging-my.yoast.com.

## Summary

This PR can be summarized in the following changelog entry:

* Fixed a bug where all MyYoast requests would go to live my.yoast.com instead of the selected value of the domain dropdown.


## Milestone

* [ ] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. Visit wp-admin/admin.php?page=wpseo_licenses on your test site. You activation status should say either "activated" or "not activated".
1. Go to my.yoast.com/sites and try to do the following:
	* If the site was not activated, register your site with MyYoast and link your Yoast SEO for WP Premium license to that site.
	* If the site was activated, see if you own the licence. If so, deactivate it. If not, proceed with step 4.
1. Refresh the page from step one. Your license status should have changed, according to what you did in MyYoast. (please be aware that the license status is cached for 60 seconds, so it may take a while before you see your changes)
1. Now, on /wp-admin/tools.php?page=yoast-test-helper you can select staging-platform in the "Domain dropdown" settings. 
1. Repeat step 1-3, but use staging-platform-my.yoast.com/sites instead. You should now be able to manage your subscription status on staging-platform. Any changes on my.yoast.com (live) should not impact your license status anymore while the "Domain dropdown" is set to something else.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.
