### PR TITLE
Add Indexable data to Query Monitor

### DIFF
--- a/src/plugin.php
+++ b/src/plugin.php
@@ -91,6 +91,7 @@ class Plugin implements Integration {
 		$this->integrations[] = new Inline_Script( $option );
 		$this->integrations[] = new Admin_Debug_Info( $option );
 		$this->integrations[] = new Indexing_Reason_Integration();
+		$this->integrations[] = new Yoast_QueryMonitor_Extension();
 	}
 
 	/**

--- a/src/query-monitor-output.php
+++ b/src/query-monitor-output.php
@@ -1,15 +1,19 @@
 <?php
 
+namespace Yoast\WP\Test_Helper;
+
 /**
  * Class to output the Indexable info within Query Monitor.
  */
-class Yoast_QueryMonitor_Output extends QM_Output_Html {
+class Query_Monitor_Output extends QM_Output_Html {
+
 	/**
 	 * Yoast_QueryMonitor_Output constructor.
 	 *
 	 * Empty to overwrite the parent class constructor.
 	 */
 	public function __construct() {
+		// Intentionally left blank.
 	}
 
 	/**
@@ -84,17 +88,19 @@ class Yoast_QueryMonitor_Output extends QM_Output_Html {
 			'schema_page_type',
 			'schema_article_type',
 			'has_ancestors',
-			'estimated_reading_time_minutes'
+			'estimated_reading_time_minutes',
 		];
 		foreach ( $keys as $key ) {
 			echo '<tr>';
-			echo '<th scope="row">' . $key . '</th>';
+			echo '<th scope="row">' . esc_html( $key ) . '</th>';
 			$val = $model->__get( $key );
 			echo '<td><pre>';
 			if ( is_array( $val ) ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 				print_r( $val );
-			} else {
-				esc_html_e( $val );
+			}
+			else {
+				echo esc_html( $val );
 			}
 			echo '</pre></td>';
 

--- a/src/query-monitor.php
+++ b/src/query-monitor.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Yoast\WP\Test_Helper;
+
+/**
+ * Class to add a Yoast SEO tab to Query Monitor.
+ */
+class Yoast_QueryMonitor_Extension implements Integration {
+
+	/**
+	 * Registers our menu item and output function.
+	 */
+	public function add_hooks() {
+		\add_filter( 'qm/output/panel_menus', array( $this, 'add_menu_panel' ), 80 );
+		\add_filter( 'qm/outputter/html', [ $this, 'output' ], 12, 1 );
+	}
+
+	/**
+	 * Adds the panel item.
+	 *
+	 * @param array $menu Array of menu items.
+	 *
+	 * @return array Array of menu items.
+	 */
+	public function add_menu_panel( array $menu ) {
+		$menu['yoast-seo'] = [
+			'id'    => 'yoast-seo',
+			'title' => 'Yoast SEO',
+			'href'  => '#qm-yoast-seo',
+		];
+
+		return $menu;
+	}
+
+	/**
+	 * Links the output to our output class.
+	 *
+	 * @param array $output Array with output for each tab.
+	 *
+	 * @return array Array with output for each tab.
+	 */
+	public function output( array $output ) {
+		$output['yoast-seo'] = new \Yoast_QueryMonitor_Output();
+
+		return $output;
+	}
+}

--- a/src/query-monitor.php
+++ b/src/query-monitor.php
@@ -5,13 +5,13 @@ namespace Yoast\WP\Test_Helper;
 /**
  * Class to add a Yoast SEO tab to Query Monitor.
  */
-class Yoast_QueryMonitor_Extension implements Integration {
+class Query_Monitor implements Integration {
 
 	/**
 	 * Registers our menu item and output function.
 	 */
 	public function add_hooks() {
-		\add_filter( 'qm/output/panel_menus', array( $this, 'add_menu_panel' ), 80 );
+		\add_filter( 'qm/output/panel_menus', [ $this, 'add_menu_panel' ], 80 );
 		\add_filter( 'qm/outputter/html', [ $this, 'output' ], 12, 1 );
 	}
 

--- a/src/yoast-querymonitor-output.php
+++ b/src/yoast-querymonitor-output.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * Class to output the Indexable info within Query Monitor.
+ */
+class Yoast_QueryMonitor_Output extends QM_Output_Html {
+	/**
+	 * Yoast_QueryMonitor_Output constructor.
+	 *
+	 * Empty to overwrite the parent class constructor.
+	 */
+	public function __construct() {
+	}
+
+	/**
+	 * Returns the name of the output.
+	 *
+	 * @return string
+	 */
+	public function name() {
+		return 'Yoast SEO';
+	}
+
+	/**
+	 * Renders the Query Monitor output integration.
+	 */
+	public function output() {
+		$this->before_non_tabular_output( 'qm-yoast-seo', $this->name() );
+
+		echo '<section>';
+		echo '<h3>Indexable</h3>';
+
+		$model = YoastSEO()->meta->for_current_page()->model;
+
+		echo '<table>';
+		echo '<tbody>';
+
+		$keys = [
+			'id',
+			'permalink',
+			'permalink_hash',
+			'object_id',
+			'object_type',
+			'object_sub_type',
+			'author_id',
+			'post_parent',
+			'title',
+			'description',
+			'breadcrumb_title',
+			'post_status',
+			'is_public',
+			'is_protected',
+			'has_public_posts',
+			'number_of_pages',
+			'canonical',
+			'primary_focus_keyword',
+			'primary_focus_keyword_score',
+			'readability_score',
+			'is_cornerstone',
+			'is_robots_noindex',
+			'is_robots_nofollow',
+			'is_robots_noarchive',
+			'is_robots_noimageindex',
+			'is_robots_nosnippet',
+			'twitter_title',
+			'twitter_image',
+			'twitter_description',
+			'twitter_image_id',
+			'twitter_image_source',
+			'open_graph_title',
+			'open_graph_description',
+			'open_graph_image',
+			'open_graph_image_id',
+			'open_graph_image_source',
+			'open_graph_image_meta',
+			'link_count',
+			'incoming_link_count',
+			'prominent_words_version',
+			'created_at',
+			'updated_at',
+			'blog_id',
+			'language',
+			'region',
+			'schema_page_type',
+			'schema_article_type',
+			'has_ancestors',
+			'estimated_reading_time_minutes'
+		];
+		foreach ( $keys as $key ) {
+			echo '<tr>';
+			echo '<th scope="row">' . $key . '</th>';
+			$val = $model->__get( $key );
+			echo '<td><pre>';
+			if ( is_array( $val ) ) {
+				print_r( $val );
+			} else {
+				esc_html_e( $val );
+			}
+			echo '</pre></td>';
+
+			echo '</tr>';
+		}
+
+		echo '</tbody>';
+		echo '</table>';
+
+		$this->after_non_tabular_output();
+	}
+}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Add Indexable data to Query Monitor

See video:

https://user-images.githubusercontent.com/487629/122607814-7062a580-d07b-11eb-99a8-97753c803041.mp4

## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Open Query Monitor, see the new Yoast SEO tab, see it has Indexables data.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.
