### PR TITLE
Add missing (limited) unindexed count transients to the indexable reset functionality

### DIFF
--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -216,7 +216,7 @@ class Yoast_SEO implements WordPress_Plugin {
 	/**
 	 * Reset all indexables related tables, options and transients, forcing Yoast SEO to rebuild the tables from scratch and reindex all indexables.
 	 *
-	 * @return bool True if successful, false otherwise.
+	 * @return bool True if the `yoast_migrations_free` option was deleted successfully, false otherwise.
 	 */
 	private function reset_indexables() {
 		global $wpdb;
@@ -242,12 +242,17 @@ class Yoast_SEO implements WordPress_Plugin {
 
 		$this->reset_indexing_notification( 'indexables-reset-by-test-helper' );
 
-		// Found in Indexable_Post_Indexation_Action::TRANSIENT_CACHE_KEY.
+		// Delete the transients that hold the (limited) total unindexed counts.
 		\delete_transient( 'wpseo_total_unindexed_posts' );
-		// Found in Indexable_Post_Type_Archive_Indexation_Action::TRANSIENT_CACHE_KEY.
+		\delete_transient( 'wpseo_total_unindexed_posts_limited' );
 		\delete_transient( 'wpseo_total_unindexed_post_type_archives' );
-		// Found in Indexable_Term_Indexation_Action::TRANSIENT_CACHE_KEY.
 		\delete_transient( 'wpseo_total_unindexed_terms' );
+		\delete_transient( 'wpseo_total_unindexed_terms_limited' );
+		\delete_transient( 'wpseo_total_unindexed_general_items' );
+		\delete_transient( 'wpseo_unindexed_post_link_count' );
+		\delete_transient( 'wpseo_unindexed_post_link_count_limited' );
+		\delete_transient( 'wpseo_unindexed_term_link_count' );
+		\delete_transient( 'wpseo_unindexed_term_link_count_limited' );
 
 		\delete_option( 'yoast_migrations_premium' );
 		return \delete_option( 'yoast_migrations_free' );

--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -253,6 +253,7 @@ class Yoast_SEO implements WordPress_Plugin {
 		\delete_transient( 'wpseo_unindexed_post_link_count_limited' );
 		\delete_transient( 'wpseo_unindexed_term_link_count' );
 		\delete_transient( 'wpseo_unindexed_term_link_count_limited' );
+		\delete_transient( 'total_unindexed_prominent_words' );
 
 		\delete_option( 'yoast_migrations_premium' );
 		return \delete_option( 'yoast_migrations_free' );

--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -216,7 +216,7 @@ class Yoast_SEO implements WordPress_Plugin {
 	/**
 	 * Reset all indexables related tables, options and transients, forcing Yoast SEO to rebuild the tables from scratch and reindex all indexables.
 	 *
-	 * @return bool True if the `yoast_migrations_free` option was deleted successfully, false otherwise.
+	 * @return bool True if successful, false otherwise.
 	 */
 	private function reset_indexables() {
 		global $wpdb;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where not all the transients that hold unindexed counts were deleted when users hit the "Reset Indexables & Migrations" button.

## Relevant technical choices:

* I searched in Free for all the `UNINDEXED_COUNT_TRANSIENT` and `UNINDEXED_LIMITED_COUNT_TRANSIENT` variables.
* I searched in Premium for these variables too (they didn't exist) but did find an unindexed count transient for prominent words in `content-action.php`.

## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

_Context_
* You can find these transients in the `options` table in your database.
* Without this PR, the following transients aren't reset when you hit "Reset Indexables & Migrations":
    * `wpseo_total_unindexed_posts_limited`
    * `wpseo_total_unindexed_terms_limited`
    * `wpseo_total_unindexed_general_items`
    * `wpseo_unindexed_post_link_count`
    * `wpseo_unindexed_post_link_count_limited`
    * `wpseo_unindexed_term_link_count`
    * `wpseo_unindexed_term_link_count_limited`
    * `total_unindexed_prominent_words` (Premium)
* With this PR, they are.
    * Some of them are recounted immediately, whereas others will just be deleted and set again when visiting certain admin pages.

For CR:
* Verify that all the transients I added in this PR exist in the codebase, and that I didn't miss any.

To test:
* Just don't see any regressions when hitting the "Reset indexables" functionality.
* I don't think it's worth it to test all the transients one by one. They're being set by visiting different places in the admin.
* Since the code is so trivial, and was already confirmed working before with the transients that were already there, if it is verified that the strings I added are correct, then we should be good.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

Fixes #
