### PR TITLE
Travis: various tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
       env: PHPLINT=1 PHPCS=1 SECURITY=1
     - php: 5.6
       env: PHPLINT=1
-    - php: "nightly"
+    - php: 8.0
       env: PHPLINT=1
     - stage: deploy
       if: tag IS present
@@ -43,10 +43,6 @@ jobs:
           repo: $TRAVIS_REPO_SLUG
           all_branches: true
 
-  allow_failures:
-    # Allow failures for unstable builds.
-    - php: "nightly"
-
 cache:
   directories:
     - .cache
@@ -54,7 +50,6 @@ cache:
     - $HOME/.composer/cache
 
 before_install:
-- composer self-update 1.10.16
 - if [[ "$COVERAGE" != "1" ]]; then phpenv config-rm xdebug.ini || echo 'No xdebug config.'; fi
 - export SECURITYCHECK_DIR=/tmp/security-checker
 
@@ -63,7 +58,7 @@ install:
   if [[ "$PHPCS" == "1" || "$PHPLINT" == "1" ]]; then
     composer install --no-interaction
   fi
-- if [[ "$SECURITY" == "1" ]]; then wget -P $SECURITYCHECK_DIR https://github.com/fabpot/local-php-security-checker/releases/download/v1.0.0/local-php-security-checker_1.0.0_linux_amd64 && chmod +x $SECURITYCHECK_DIR/local-php-security-checker_1.0.0_linux_amd64;fi
+- if [[ "$SECURITY" == "1" ]]; then wget -P $SECURITYCHECK_DIR https://github.com/fabpot/local-php-security-checker/releases/download/v1.2.0/local-php-security-checker_1.2.0_linux_amd64 && chmod +x $SECURITYCHECK_DIR/local-php-security-checker_1.2.0_linux_amd64;fi
 
 before_script:
 - export -f travis_fold
@@ -97,4 +92,4 @@ script:
 - if [[ $TRAVIS_PHP_VERSION == "5.6" || $TRAVIS_PHP_VERSION == "7.4" ]]; then composer validate --no-check-all; fi
 
 # Check for known security vulnerabilities in the currently locked-in dependencies.
-- if [[ "$SECURITY" == "1" ]]; then $SECURITYCHECK_DIR/local-php-security-checker_1.0.0_linux_amd64 --path=$(pwd)/composer.lock;fi
+- if [[ "$SECURITY" == "1" ]]; then $SECURITYCHECK_DIR/local-php-security-checker_1.2.0_linux_amd64 --path=$(pwd)/composer.lock;fi


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Improve CI

## Relevant technical choices:

* Replace `nightly` with `8.0`
    At this time, the current PHP 8.0 version is `8.0.11`. The Travis PHP `8.0` image yields PHP `8.0.9`, which is good enough for PHP 8.0.
    `nightly` however is PHP `8.0.3` and hasn't been updated since Feb 2021, so running tests against that image is completely useless at this time.
* Remove the `composer self-update` for Composer 1.x.
    This was a temporary measure when Composer first came out, but hasn't been necessary for a while.
* Upgrade the PHP Security Checker
    Ref: https://github.com/fabpot/local-php-security-checker/blob/main/CHANGELOG.md


## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ If the build passes, we're good.
