### PR TITLE
Add buttons to reset the free and premium installation success pages

### DIFF
--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -71,14 +71,16 @@ class Yoast_SEO implements WordPress_Plugin {
 	 */
 	public function get_features() {
 		return [
-			'internal_link_count'         => \esc_html__( 'Internal link counter', 'yoast-test-helper' ),
-			'prominent_words_calculation' => \esc_html__( 'Prominent words calculation', 'yoast-test-helper' ),
-			'reset_configuration_wizard'  => \esc_html__( 'Configuration wizard', 'yoast-test-helper' ),
-			'reset_notifications'         => \esc_html__( 'Notifications', 'yoast-test-helper' ),
-			'reset_site_information'      => \esc_html__( 'Site information', 'yoast-test-helper' ),
-			'reset_tracking'              => \esc_html__( 'Tracking', 'yoast-test-helper' ),
-			'reset_indexables'            => \esc_html__( 'Indexables tables & migrations', 'yoast-test-helper' ),
-			'reset_capabilities'          => \esc_html__( 'SEO roles & capabilities', 'yoast-test-helper' ),
+			'internal_link_count'                => \esc_html__( 'Internal link counter', 'yoast-test-helper' ),
+			'prominent_words_calculation'        => \esc_html__( 'Prominent words calculation', 'yoast-test-helper' ),
+			'reset_configuration_wizard'         => \esc_html__( 'Configuration wizard', 'yoast-test-helper' ),
+			'reset_notifications'                => \esc_html__( 'Notifications', 'yoast-test-helper' ),
+			'reset_site_information'             => \esc_html__( 'Site information', 'yoast-test-helper' ),
+			'reset_tracking'                     => \esc_html__( 'Tracking', 'yoast-test-helper' ),
+			'reset_indexables'                   => \esc_html__( 'Indexables tables & migrations', 'yoast-test-helper' ),
+			'reset_capabilities'                 => \esc_html__( 'SEO roles & capabilities', 'yoast-test-helper' ),
+			'reset_free_installation_success'    => \esc_html__( 'Free installation success page', 'yoast-test-helper' ),
+			'reset_premium_installation_success' => \esc_html__( 'Premium installation success page', 'yoast-test-helper' ),
 		];
 	}
 
@@ -110,6 +112,12 @@ class Yoast_SEO implements WordPress_Plugin {
 				return $this->reset_tracking();
 			case 'reset_capabilities':
 				$this->reset_capabilities();
+				return true;
+			case 'reset_free_installation_success':
+				$this->reset_free_installation_success_page();
+				return true;
+			case 'reset_premium_installation_success':
+				$this->reset_premium_installation_success_page();
 				return true;
 		}
 
@@ -293,5 +301,23 @@ class Yoast_SEO implements WordPress_Plugin {
 			$premium_capability_manager->remove();
 			$premium_capability_manager->add();
 		}
+	}
+
+	/**
+	 * Resets the Free installation success page timestamp such that on reactivation the user is redirected again.
+	 *
+	 * @return void
+	 */
+	protected function reset_free_installation_success_page() {
+		WPSEO_Options::set( 'activation_redirect_timestamp_free', '0' );
+	}
+
+	/**
+	 * Resets the Premium installation success page timestamp such that on reactivation the user is redirected again.
+	 *
+	 * @return void
+	 */
+	protected function reset_premium_installation_success_page() {
+		WPSEO_Options::set( 'activation_redirect_timestamp', '0' );
 	}
 }


### PR DESCRIPTION
## Summary

⚠️ Note: you can only use the Free button when you have `Yoast SEO` **activated** and you can only use the Premium button when you have both `Yoast SEO` **and** `Yoast SEO Premium` **activated**.

This PR can be summarized in the following changelog entry:

* Adds buttons to reset the Free and Premium installation success screens, such that on reactivating the plugins, the corresponding installation success screen is shown again.

## Relevant technical choices:

*

## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate Yoast SEO Free and Premium and the Yoast Test Helper.
* Navigate to Tools > Yoast Test
* Use the `Reset Free installation success page` button, see you get a success message
* In the database, check that `activation_redirect_timestamp_free` in `wpseo` has been set to '0'
* Use the `Reset Premium installation success page` button, see you get a success message
* In the database, check that `activation_redirect_timestamp` in `wpseo_premium` has been set to '0'
* Deactivate Yoast SEO Free and Premium
* Activate Yoast SEO Free, see you are redirected to the free installation success page
* Activate Yoast SEO Premium, see you are redirected to the premium installation success page

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Activate Yoast SEO Free and Premium and the Yoast Test Helper.
* Navigate to Tools > Yoast Test
* Use the `Reset Free installation success page` button, see you get a success message
* Use the `Reset Premium installation success page` button, see you get a success message
* Deactivate Yoast SEO Free and Premium
* Activate Yoast SEO Free, see you are redirected to the free installation success page
* Activate Yoast SEO Premium, see you are redirected to the premium installation success page

Fixes #
