### PR TITLE
GH Actions: fix the deploy checkout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -145,6 +145,7 @@ jobs:
           ref: ${{ env.DIST_DEFAULT_BRANCH }}
           # Personal Access Token for (push) access to the dist version of the repo.
           token: ${{ secrets.YOASTBOT_CI_PAT_DIST }}
+          fetch-depth: 0
 
       - name: "Create branch/Switch to branch"
         if: ${{ steps.set_vars.outputs.BRANCH != env.DIST_DEFAULT_BRANCH }}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Improve CI

## Relevant technical choices:

By default the `actions/checkout` does a shallow clone. This means that other branches will not be known, so would always be created as new.
By setting `fetch-depth` to `0`, a complete clone will be made, including all tags and branches.

This will make the deploy slightly slower, but as the `dist` repos are nowhere near as huge as the `dev` repos, this should still be relatively limited.
If this at some point would become problematic, we can have a think about using a "sensible number" for `fetch-depth` (something like `1000` or so).

Note: this change isn't for the most part not needed for this repo as the repo only deploys on tags. However, it will still make the workflow more stable for those exceptional times when the workflow would be manually triggered.

Refs:
* https://github.com/actions/checkout#usage
* https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches

## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* 