### PR TITLE
DUPP-146 reset first time configuration and premium workouts

### DIFF
--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -82,6 +82,7 @@ class Yoast_SEO implements WordPress_Plugin {
 			'reset_free_installation_success'    => \esc_html__( 'Free installation success page', 'yoast-test-helper' ),
 			'reset_premium_installation_success' => \esc_html__( 'Premium installation success page', 'yoast-test-helper' ),
 			'reset_first_time_configuration'     => \esc_html__( 'First time configuration', 'yoast-test-helper' ),
+			'reset_premium_workouts'             => \esc_html__( 'Premium workouts', 'yoast-test-helper' ),
 		];
 	}
 
@@ -122,6 +123,9 @@ class Yoast_SEO implements WordPress_Plugin {
 				return true;
 			case 'reset_first_time_configuration':
 				$this->reset_first_time_configuration();
+				return true;
+			case 'reset_premium_workouts':
+				$this->reset_premium_workouts();
 				return true;
 		}
 
@@ -334,5 +338,14 @@ class Yoast_SEO implements WordPress_Plugin {
 		$workouts_data                  = WPSEO_Options::get( 'workouts_data' );
 		$workouts_data['configuration'] = [ 'finishedSteps' => [] ];
 		WPSEO_Options::set( 'workouts_data', $workouts_data );
+	}
+
+	/**
+	 * Resets the Premium workouts.
+	 *
+	 * @return void
+	 */
+	protected function reset_premium_workouts() {
+		WPSEO_Options::set( 'workouts', [ 'cornerstone' => [ 'finishedSteps' => [] ] ] );
 	}
 }

--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -331,8 +331,8 @@ class Yoast_SEO implements WordPress_Plugin {
 	 * @return void
 	 */
 	protected function reset_first_time_configuration() {
-		$workouts_data = WPSEO_Options::get( 'workouts_data' );
-		$workouts_data['configuration'] =  [ 'finishedSteps' => [] ];
+		$workouts_data                  = WPSEO_Options::get( 'workouts_data' );
+		$workouts_data['configuration'] = [ 'finishedSteps' => [] ];
 		WPSEO_Options::set( 'workouts_data', $workouts_data );
 	}
 }

--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -81,6 +81,7 @@ class Yoast_SEO implements WordPress_Plugin {
 			'reset_capabilities'                 => \esc_html__( 'SEO roles & capabilities', 'yoast-test-helper' ),
 			'reset_free_installation_success'    => \esc_html__( 'Free installation success page', 'yoast-test-helper' ),
 			'reset_premium_installation_success' => \esc_html__( 'Premium installation success page', 'yoast-test-helper' ),
+			'reset_first_time_configuration'     => \esc_html__( 'First time configuration', 'yoast-test-helper' ),
 		];
 	}
 
@@ -118,6 +119,9 @@ class Yoast_SEO implements WordPress_Plugin {
 				return true;
 			case 'reset_premium_installation_success':
 				$this->reset_premium_installation_success_page();
+				return true;
+			case 'reset_first_time_configuration':
+				$this->reset_first_time_configuration();
 				return true;
 		}
 
@@ -319,5 +323,16 @@ class Yoast_SEO implements WordPress_Plugin {
 	 */
 	protected function reset_premium_installation_success_page() {
 		WPSEO_Options::set( 'activation_redirect_timestamp', '0' );
+	}
+
+	/**
+	 * Resets the First-time configuration.
+	 *
+	 * @return void
+	 */
+	protected function reset_first_time_configuration() {
+		$workouts_data = WPSEO_Options::get( 'workouts_data' );
+		$workouts_data['configuration'] =  [ 'finishedSteps' => [] ];
+		WPSEO_Options::set( 'workouts_data', $workouts_data );
 	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Introduces buttons to reset the first-time configuration and the premium workouts.

## Relevant technical choices:

* The resetting currently targets the first-time configuration as a workout, it will need to be updated in the future when it's moved/refactored in the internals
* The button resets only the state of the steps for the first-time configuration, not the content of the input boxes.

## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate Yoast SEO Free and the Yoast Test Helper.
* Start the configuration workout and complete some steps (or complete the full workout)
* Navigate to Tools > Yoast Test
* Use the `Reset First-time configuration` button, see you get a success message
* Navigate again to the workouts page and see that the configuration workout is not started.

Check that this doesn't impact the premium workouts:
* Install and activate Premium
* Start the configuration workout and complete some steps (or complete the full workout)
* start or complete one or both premium workouts
* Navigate to Tools > Yoast Test
* Use the `Reset First-time configuration` button, see you get a success message
* Navigate again to the workouts page and see that the configuration workout is not started, but the other workout haven't change their progress.
* Navigate to Tools > Yoast Test
* Use the `Reset Premium Workouts` button, see you get a success message
* Navigate again to the workouts page and see that the premium workouts' progress has been reset.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

Fixes [DUPP-146]


[DUPP-146]: https://yoast.atlassian.net/browse/DUPP-146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ