### PR TITLE
DUPP-284 Introduce button to reset options to defaults

### DIFF
--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -84,6 +84,7 @@ class Yoast_SEO implements WordPress_Plugin {
 			'reset_first_time_configuration'     => \esc_html__( 'First time configuration', 'yoast-test-helper' ),
 			'reset_premium_workouts'             => \esc_html__( 'Premium workouts', 'yoast-test-helper' ),
 			'reset_options'                      => \esc_html__( 'Options', 'yoast-test-helper' ),
+			'reset_cornerstone_flags'            => \esc_html__( 'Cornerstone flags', 'yoast-test-helper' ),
 		];
 	}
 
@@ -130,6 +131,9 @@ class Yoast_SEO implements WordPress_Plugin {
 				return true;
 			case 'reset_options':
 				$this->reset_options();
+				return true;
+			case 'reset_cornerstone_flags':
+				$this->reset_cornerstone_flags();
 				return true;
 		}
 
@@ -360,5 +364,15 @@ class Yoast_SEO implements WordPress_Plugin {
 	 */
 	protected function reset_options() {
 		WPSEO_Options::reset();
+	}
+
+	/**
+	 * Resets the cornerstone flags set for posts.
+	 *
+	 * @return void
+	 */
+	protected function reset_cornerstone_flags() {
+		global $wpdb;
+		$wpdb->query( 'DELETE FROM ' . $wpdb->prefix . 'postmeta WHERE meta_key = "_yoast_wpseo_is_cornerstone"' );
 	}
 }

--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -81,8 +81,8 @@ class Yoast_SEO implements WordPress_Plugin {
 			'reset_capabilities'                 => \esc_html__( 'SEO roles & capabilities', 'yoast-test-helper' ),
 			'reset_free_installation_success'    => \esc_html__( 'Free installation success page', 'yoast-test-helper' ),
 			'reset_premium_installation_success' => \esc_html__( 'Premium installation success page', 'yoast-test-helper' ),
-			'reset_first_time_configuration'     => \esc_html__( 'First time configuration', 'yoast-test-helper' ),
-			'reset_premium_workouts'             => \esc_html__( 'Premium workouts', 'yoast-test-helper' ),
+			'reset_first_time_configuration'     => \esc_html__( 'First time configuration progress', 'yoast-test-helper' ),
+			'reset_premium_workouts'             => \esc_html__( 'Premium workouts progress', 'yoast-test-helper' ),
 			'reset_options'                      => \esc_html__( 'Options', 'yoast-test-helper' ),
 			'reset_cornerstone_flags'            => \esc_html__( 'Cornerstone flags', 'yoast-test-helper' ),
 		];

--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -83,6 +83,7 @@ class Yoast_SEO implements WordPress_Plugin {
 			'reset_premium_installation_success' => \esc_html__( 'Premium installation success page', 'yoast-test-helper' ),
 			'reset_first_time_configuration'     => \esc_html__( 'First time configuration', 'yoast-test-helper' ),
 			'reset_premium_workouts'             => \esc_html__( 'Premium workouts', 'yoast-test-helper' ),
+			'reset_options'                      => \esc_html__( 'Options', 'yoast-test-helper' ),
 		];
 	}
 
@@ -126,6 +127,9 @@ class Yoast_SEO implements WordPress_Plugin {
 				return true;
 			case 'reset_premium_workouts':
 				$this->reset_premium_workouts();
+				return true;
+			case 'reset_options':
+				$this->reset_options();
 				return true;
 		}
 
@@ -347,5 +351,14 @@ class Yoast_SEO implements WordPress_Plugin {
 	 */
 	protected function reset_premium_workouts() {
 		WPSEO_Options::set( 'workouts', [ 'cornerstone' => [ 'finishedSteps' => [] ] ] );
+	}
+
+	/**
+	 * Resets the option to the defaults as if the plugin were installed the first time.
+	 *
+	 * @return void
+	 */
+	protected function reset_options() {
+		WPSEO_Options::reset();
 	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Introduces buttons to reset the options and the cornerstone flags

## Relevant technical choices:

* Deleting the post meta that flags cornerstone content is not enough to empty the cornerston workout: hte indexables need to be rebuilt. We chose to not perform a purge of indexables with the new button because it can be unexpected and undesired to users.
* I updated the "First time configuration" and "Premium workouts" labels adding "progress" to make it clearer that only progress is reset, not the content of the steps.

## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate Yoast SEO Free and Premium and the Yoast Test Helper.
* Edit some options e.g. in Search Appearance and Social so they differ from the defaults
  *  make sure to change some Premium options too, such as the social templates in Search appearance
* Navigate to Tools > Yoast Test
* Use the `Reset Options` button, see you get a success message
* Navigate again to where you changed the options to see they are back to default values
* do a quick smoke test (edit a post or a term, navigate the settings) to check that everything's working fine
* Start the Cornerstone workout and set some posts/pages as cornerstone in the first step
* Navigate to Tools > Yoast Test
* Use the `Reset cornerstone flags` button, see you get a success message
* edit the posts/pages you set as cornerstone to check that they are not flagged as such anymore
  * do not save
* Use the `Reset Indexables tables & migrations` button, see you get a success message (**see above**)
* visit the Cornerstone workout and see that nothing is set as cornerstone now

*** Also test the above on multisite, and check that resetting options in a subsite doesn't affect options in other subsites ***

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

Fixes [DUPP-284]


[DUPP-284]: https://yoast.atlassian.net/browse/DUPP-284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ