### PR TITLE
Fix old version in "wpseo" option after downgrade via Yoast Test Helper

### DIFF
--- a/src/downgrader.php
+++ b/src/downgrader.php
@@ -187,12 +187,12 @@ class Downgrader implements Integration {
 		}
 
 		$downgrade_version = function( $option ) use ( $target_version ) {
-			$option['version'] = sanitize_text_field( $target_version );
+			$option['version'] = \sanitize_text_field( $target_version );
 			return $option;
 		};
 
-		add_filter( 'sanitize_option_wpseo', $downgrade_version, 20 );
+		\add_filter( 'sanitize_option_wpseo', $downgrade_version, 20 );
 		WPSEO_Options::set( 'version', $target_version );
-		remove_filter( 'sanitize_option_wpseo', $downgrade_version );
+		\remove_filter( 'sanitize_option_wpseo', $downgrade_version );
 	}
 }

--- a/src/downgrader.php
+++ b/src/downgrader.php
@@ -185,6 +185,14 @@ class Downgrader implements Integration {
 		if ( \is_wp_error( $result ) ) {
 			throw new Exception( \__( 'Could not install the requested version.', 'yoast-test-helper' ) );
 		}
+
+		$downgrade_version = function( $option ) use ( $target_version ) {
+			$option['version'] = sanitize_text_field( $target_version );
+			return $option;
+		};
+
+		add_filter( 'sanitize_option_wpseo', $downgrade_version, 20 );
 		WPSEO_Options::set( 'version', $target_version );
+		remove_filter( 'sanitize_option_wpseo', $downgrade_version );
 	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the Yoast version would not updated in the db after a downgrade.

## Relevant technical choices:

*

## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Yoast SEO 18.4 RC5.
* Install and activate Yoast Test Helper 1.16-RC1.
* Go to Test Helper → Downgrade Yoast SEO → enter 18.0 and click save.
* You see successful message.
* Check Plugins page - Yoast SEO is 18.0.
Without this PR:
* Check _options table in DB:wpseo still contains s:7:"version";s:8:"18.4-RC5";
Without this PR:
* Check _options table in DB:wpseo still contains s:7:"version";s:4:"18.0";


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

Fixes https://yoast.atlassian.net/browse/DUPP-351
