### PR TITLE
Fix migration version

### DIFF
--- a/src/downgrader.php
+++ b/src/downgrader.php
@@ -164,6 +164,7 @@ class Downgrader implements Integration {
 				);
 			}
 		}
+		$migration_status->set_success( 'free', $target_version );
 
 		$working_dir = $upgrader->unpack_package( $downloaded_archive, true );
 		if ( \is_wp_error( $working_dir ) ) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where a wrong migrations version would be set in the DB after a downgrade.

## Relevant technical choices:

*

## Milestone

* [ ] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Yoast SEO 18.4 RC5.
* Install and activate Yoast Test Helper 1.16-RC1.
* Go to Test Helper → Downgrade Yoast SEO → enter 18.0 and click save.
* You see successful message.
* Check _options table in DB: `yoast_migrations_free`  contains s:7:"version";s:4:"18.0";

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

Fixes #
