### PR TITLE
Remove Reset Configuration Wizard button

### DIFF
--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -73,7 +73,6 @@ class Yoast_SEO implements WordPress_Plugin {
 		return [
 			'internal_link_count'                => \esc_html__( 'Internal link counter', 'yoast-test-helper' ),
 			'prominent_words_calculation'        => \esc_html__( 'Prominent words calculation', 'yoast-test-helper' ),
-			'reset_configuration_wizard'         => \esc_html__( 'Configuration wizard', 'yoast-test-helper' ),
 			'reset_notifications'                => \esc_html__( 'Notifications', 'yoast-test-helper' ),
 			'reset_site_information'             => \esc_html__( 'Site information', 'yoast-test-helper' ),
 			'reset_tracking'                     => \esc_html__( 'Tracking', 'yoast-test-helper' ),
@@ -103,8 +102,6 @@ class Yoast_SEO implements WordPress_Plugin {
 			case 'prominent_words_calculation':
 				$this->reset_prominent_words_calculation();
 				return true;
-			case 'reset_configuration_wizard':
-				return $this->reset_configuration_wizard();
 			case 'reset_indexables':
 				return $this->reset_indexables();
 			case 'reset_notifications':
@@ -225,16 +222,6 @@ class Yoast_SEO implements WordPress_Plugin {
 	 */
 	private function reset_tracking() {
 		return \delete_option( 'wpseo_tracking_last_request' );
-	}
-
-	/**
-	 * Resets the configuration wizard to its initial state.
-	 *
-	 * @return bool True if successful, false otherwise.
-	 */
-	private function reset_configuration_wizard() {
-
-		return WPSEO_Options::set( 'show_onboarding_notice', true );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Removes the obsolete `Reset Configuration Wizard` button.

## Relevant technical choices:

*

## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to Tools->Yoast Test
* Confirm that the Reset Configuration Wizard is no longer there

Also:
* Click a different button, maybe `Reset Options` and confirm it works as expected.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

Fixes #
