### PR TITLE
Add schema endpoint to every URL

### DIFF
--- a/src/schema.php
+++ b/src/schema.php
@@ -85,7 +85,8 @@ class Schema implements Integration {
 
 		\header( 'Content-Type: application/ld+json' );
 		\header( 'Link: <' . $url . '>; rel="canonical"' );
-		echo \wp_json_encode( \YoastSEO()->meta->for_current_page()->schema, ( JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- This is our self generated Schema, no need for escaping.
+		echo WPSEO_Utils::format_json_encode( \YoastSEO()->meta->for_current_page()->schema );
 		exit;
 	}
 
@@ -103,6 +104,7 @@ class Schema implements Integration {
 
 		$output .= Form_Presenter::create_checkbox(
 			'enable_schema_endpoint',
+			// translators: %s is replaced by `<code>/schema/</code>`.
 			sprintf( \esc_html__( 'Enable the %s endpoint for every URL.', 'yoast-test-helper' ), '<code>/schema/</code>' ),
 			$this->option->get( 'enable_schema_endpoint' )
 		);


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds a `schema` endpoint to any URL. Suffix the URL with `/schema/` or `?schema` and you'll get only the Schema for that URL, pretty printed.

![schema-endpoint](https://user-images.githubusercontent.com/487629/175265553-fd2892cc-b434-44db-8466-cddd366ce24a.png)


## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Enable the option under Schema in settings.
* Open any URL, including the homepage URL itself, and add `schema/` to the URL.
* See the Schema output as nicely formatted JSON.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.
