### PR TITLE
Adds test helper controls for setting indexables values

### DIFF
--- a/src/indexables-page.php
+++ b/src/indexables-page.php
@@ -90,7 +90,7 @@ class Indexables_Page implements Integration {
 		}
 
 		$output .= '<label for="indexables_analyzed_posts_threshold">' . \esc_html__( 'The minimum threshold for the amount of analyzed posts:', 'yoast-test-helper' ) . '</label>';
-		$output .= '<input type="text" size="5" value="' . $value . '" placeholder="' . $placeholder_analyzed_thresholds . '" name="indexables_analyzed_posts_threshold" id="indexables_analyzed_posts_threshold"/><span>%</span><br/>';
+		$output .= '<input type="number" step=".01" size="5" min=0 max=100 value="' . $value . '" placeholder="' . $placeholder_analyzed_thresholds . '" name="indexables_analyzed_posts_threshold" id="indexables_analyzed_posts_threshold"/><span>%</span><br/>';
 
 
 		return Form_Presenter::get_html( \__( 'Integration page thresholds', 'yoast-test-helper' ), 'yoast_seo_test_indexables_page', $output );

--- a/src/indexables-page.php
+++ b/src/indexables-page.php
@@ -105,14 +105,14 @@ class Indexables_Page implements Integration {
 		if ( \check_admin_referer( 'yoast_seo_test_indexables_page' ) !== false ) {
 			$indexables_posts_threshold = null;
 			if ( isset( $_POST['indexables_posts_threshold'] ) ) {
-				$indexables_posts_threshold = \sanitize_text_field( wp_unslash( $_POST['indexables_posts_threshold'] ) );
+				$indexables_posts_threshold = \sanitize_text_field( \wp_unslash( $_POST['indexables_posts_threshold'] ) );
 			}
 			$this->option->set( 'indexables_posts_threshold', $indexables_posts_threshold );
 
 			$indexables_analyzed_posts_threshold = null;
 
 			if ( isset( $_POST['indexables_analyzed_posts_threshold'] ) && $_POST['indexables_analyzed_posts_threshold'] > 0 && $_POST['indexables_analyzed_posts_threshold'] <= 100 ) {
-				$indexables_analyzed_posts_threshold = \sanitize_text_field( wp_unslash( $_POST['indexables_analyzed_posts_threshold'] ) );
+				$indexables_analyzed_posts_threshold = \sanitize_text_field( \wp_unslash( $_POST['indexables_analyzed_posts_threshold'] ) );
 			}
 			$this->option->set( 'indexables_analyzed_posts_threshold', ( $indexables_analyzed_posts_threshold / 100 ) );
 		}

--- a/src/indexables-page.php
+++ b/src/indexables-page.php
@@ -74,9 +74,9 @@ class Indexables_Page implements Integration {
 		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Using WPSEO hook.
 		$placeholder_thresholds = \apply_filters( 'wpseo_posts_threshold', Indexables_Page_Helper::POSTS_THRESHOLD );
 		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Using WPSEO hook.
-		$placeholder_analyzed_thresholds = \apply_filters( 'wpseo_analyzed_posts_threshold', Indexables_Page_Helper::ANALYSED_POSTS_THRESHOLD );
-
-		$value = '';
+		$placeholder_analyzed_thresholds  = \apply_filters( 'wpseo_analyzed_posts_threshold', Indexables_Page_Helper::ANALYSED_POSTS_THRESHOLD );
+		$placeholder_analyzed_thresholds *= 100;
+		$value                            = '';
 		if ( $this->option->get( 'indexables_posts_threshold' ) > 0 ) {
 			$value = $this->option->get( 'indexables_posts_threshold' );
 		}
@@ -86,11 +86,11 @@ class Indexables_Page implements Integration {
 
 		$value = '';
 		if ( $this->option->get( 'indexables_analyzed_posts_threshold' ) > 0 ) {
-			$value = $this->option->get( 'indexables_analyzed_posts_threshold' );
+			$value = ( $this->option->get( 'indexables_analyzed_posts_threshold' ) * 100 );
 		}
 
 		$output .= '<label for="indexables_analyzed_posts_threshold">' . \esc_html__( 'The minimum threshold for the amount of analyzed posts:', 'yoast-test-helper' ) . '</label>';
-		$output .= '<input type="number" step=".01" size="5" min=0 max=100 value="' . $value . '" placeholder="' . $placeholder_analyzed_thresholds . '" name="indexables_analyzed_posts_threshold" id="indexables_analyzed_posts_threshold"/><span>%</span><br/>';
+		$output .= '<input type="number" size="5" min=1 max=100 value="' . $value . '" placeholder="' . $placeholder_analyzed_thresholds . '" name="indexables_analyzed_posts_threshold" id="indexables_analyzed_posts_threshold"/><span>%</span><br/>';
 
 
 		return Form_Presenter::get_html( \__( 'Integration page thresholds', 'yoast-test-helper' ), 'yoast_seo_test_indexables_page', $output );
@@ -105,18 +105,16 @@ class Indexables_Page implements Integration {
 		if ( \check_admin_referer( 'yoast_seo_test_indexables_page' ) !== false ) {
 			$indexables_posts_threshold = null;
 			if ( isset( $_POST['indexables_posts_threshold'] ) ) {
-				$indexables_posts_threshold = \filter_input( \INPUT_POST, 'indexables_posts_threshold', \FILTER_SANITIZE_NUMBER_INT );
+				$indexables_posts_threshold = \sanitize_text_field( wp_unslash( $_POST['indexables_posts_threshold'] ) );
 			}
 			$this->option->set( 'indexables_posts_threshold', $indexables_posts_threshold );
 
 			$indexables_analyzed_posts_threshold = null;
 
-			if ( isset( $_POST['indexables_analyzed_posts_threshold'] ) ) {
-				$analyzed_threshold_post             = \filter_input( \INPUT_POST, 'indexables_analyzed_posts_threshold', \FILTER_SANITIZE_STRING );
-				$indexables_analyzed_posts_threshold = \str_replace( ',', '.', $analyzed_threshold_post );
-				$indexables_analyzed_posts_threshold = \filter_var( $indexables_analyzed_posts_threshold, \FILTER_SANITIZE_NUMBER_FLOAT, \FILTER_FLAG_ALLOW_FRACTION );
+			if ( isset( $_POST['indexables_analyzed_posts_threshold'] ) && $_POST['indexables_analyzed_posts_threshold'] > 0 && $_POST['indexables_analyzed_posts_threshold'] <= 100 ) {
+				$indexables_analyzed_posts_threshold = \sanitize_text_field( wp_unslash( $_POST['indexables_analyzed_posts_threshold'] ) );
 			}
-			$this->option->set( 'indexables_analyzed_posts_threshold', $indexables_analyzed_posts_threshold );
+			$this->option->set( 'indexables_analyzed_posts_threshold', ( $indexables_analyzed_posts_threshold / 100 ) );
 		}
 
 		\wp_safe_redirect( \self_admin_url( 'tools.php?page=' . \apply_filters( 'Yoast\WP\Test_Helper\admin_page', '' ) ) );

--- a/src/indexables-page.php
+++ b/src/indexables-page.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Yoast\WP\Test_Helper;
+
+use Yoast\WP\SEO\Helpers\Indexables_Page_Helper;
+
+/**
+ * Class to manage registering and rendering the admin page in WordPress.
+ */
+class Indexables_Page implements Integration {
+
+	/**
+	 * Holds our option instance.
+	 *
+	 * @var Option
+	 */
+	private $option;
+
+	/**
+	 * Class constructor.
+	 *
+	 * @param Option $option Our option array.
+	 */
+	public function __construct( Option $option ) {
+		$this->option = $option;
+	}
+
+	/**
+	 * Adds the required hooks for this class.
+	 */
+	public function add_hooks() {
+		\add_filter( 'wpseo_posts_threshold', [ $this, 'indexables_posts_threshold' ], 10, 1 );
+		\add_filter( 'wpseo_analyzed_posts_threshold', [ $this, 'indexables_analyzed_posts_threshold' ], 10, 1 );
+
+		\add_action( 'admin_post_yoast_seo_test_indexables_page', [ $this, 'handle_submit' ] );
+	}
+
+	/**
+	 * Filter minimum post threshold.
+	 *
+	 * @param int $number The current post threshold.
+	 *
+	 * @return int The current post threshold.
+	 */
+	public function indexables_posts_threshold( $number ) {
+		if ( $this->option->get( 'indexables_posts_threshold' ) > 0 ) {
+			return $this->option->get( 'indexables_posts_threshold' );
+		}
+
+		return $number;
+	}
+
+	/**
+	 * Filter minimum analyzed post threshold.
+	 *
+	 * @param int $number The current analyzed post threshold.
+	 *
+	 * @return int The current analyzed post threshold.
+	 */
+	public function indexables_analyzed_posts_threshold( $number ) {
+		if ( $this->option->get( 'indexables_analyzed_posts_threshold' ) > 0 ) {
+			return $this->option->get( 'indexables_analyzed_posts_threshold' );
+		}
+
+		return $number;
+	}
+
+	/**
+	 * Retrieves the controls.
+	 *
+	 * @return string The HTML to use to render the controls.
+	 */
+	public function get_controls() {
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Using WPSEO hook.
+		$placeholder_thresholds = \apply_filters( 'wpseo_posts_threshold', Indexables_Page_Helper::POSTS_THRESHOLD );
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Using WPSEO hook.
+		$placeholder_analyzed_thresholds = \apply_filters( 'wpseo_analyzed_posts_threshold', Indexables_Page_Helper::ANALYSED_POSTS_THRESHOLD );
+
+		$value = '';
+		if ( $this->option->get( 'indexables_posts_threshold' ) > 0 ) {
+			$value = $this->option->get( 'indexables_posts_threshold' );
+		}
+
+		$output  = '<label for="indexables_posts_threshold">' . \esc_html__( 'Minimum threshold for the amount of posts needed:', 'yoast-test-helper' ) . '</label>';
+		$output .= '<input type="number" size="5" value="' . $value . '" placeholder="' . $placeholder_thresholds . '" name="indexables_posts_threshold" id="indexables_posts_threshold"/><br/>';
+
+		$value = '';
+		if ( $this->option->get( 'indexables_analyzed_posts_threshold' ) > 0 ) {
+			$value = $this->option->get( 'indexables_analyzed_posts_threshold' );
+		}
+
+		$output .= '<label for="indexables_analyzed_posts_threshold">' . \esc_html__( 'The minimum threshold for the amount of analyzed posts in the site:', 'yoast-test-helper' ) . '</label>';
+		$output .= '<input type="text" size="5" value="' . $value . '" placeholder="' . $placeholder_analyzed_thresholds . '" name="indexables_analyzed_posts_threshold" id="indexables_analyzed_posts_threshold"/><br/>';
+
+
+		return Form_Presenter::get_html( \__( 'Integration page thresholds', 'yoast-test-helper' ), 'yoast_seo_test_indexables_page', $output );
+	}
+
+	/**
+	 * Handles the form submit.
+	 *
+	 * @return void
+	 */
+	public function handle_submit() {
+		if ( \check_admin_referer( 'yoast_seo_test_indexables_page' ) !== false ) {
+			$indexables_posts_threshold = null;
+			if ( isset( $_POST['indexables_posts_threshold'] ) ) {
+				$indexables_posts_threshold = \filter_input( \INPUT_POST, 'indexables_posts_threshold', \FILTER_SANITIZE_NUMBER_INT );
+			}
+			$this->option->set( 'indexables_posts_threshold', $indexables_posts_threshold );
+
+			$indexables_analyzed_posts_threshold = null;
+
+			if ( isset( $_POST['indexables_analyzed_posts_threshold'] ) ) {
+				$analyzed_threshold_post             = \filter_input( \INPUT_POST, 'indexables_analyzed_posts_threshold', \FILTER_SANITIZE_STRING );
+				$indexables_analyzed_posts_threshold = \str_replace( ',', '.', $analyzed_threshold_post );
+				$indexables_analyzed_posts_threshold = \filter_var( $indexables_analyzed_posts_threshold, \FILTER_SANITIZE_NUMBER_FLOAT, \FILTER_FLAG_ALLOW_FRACTION );
+			}
+			$this->option->set( 'indexables_analyzed_posts_threshold', $indexables_analyzed_posts_threshold );
+		}
+
+		\wp_safe_redirect( \self_admin_url( 'tools.php?page=' . \apply_filters( 'Yoast\WP\Test_Helper\admin_page', '' ) ) );
+	}
+}

--- a/src/indexables-page.php
+++ b/src/indexables-page.php
@@ -89,8 +89,8 @@ class Indexables_Page implements Integration {
 			$value = $this->option->get( 'indexables_analyzed_posts_threshold' );
 		}
 
-		$output .= '<label for="indexables_analyzed_posts_threshold">' . \esc_html__( 'The minimum threshold for the amount of analyzed posts in the site:', 'yoast-test-helper' ) . '</label>';
-		$output .= '<input type="text" size="5" value="' . $value . '" placeholder="' . $placeholder_analyzed_thresholds . '" name="indexables_analyzed_posts_threshold" id="indexables_analyzed_posts_threshold"/><br/>';
+		$output .= '<label for="indexables_analyzed_posts_threshold">' . \esc_html__( 'The minimum threshold for the amount of analyzed posts:', 'yoast-test-helper' ) . '</label>';
+		$output .= '<input type="text" size="5" value="' . $value . '" placeholder="' . $placeholder_analyzed_thresholds . '" name="indexables_analyzed_posts_threshold" id="indexables_analyzed_posts_threshold"/><span>%</span><br/>';
 
 
 		return Form_Presenter::get_html( \__( 'Integration page thresholds', 'yoast-test-helper' ), 'yoast_seo_test_indexables_page', $output );

--- a/src/plugin.php
+++ b/src/plugin.php
@@ -83,6 +83,7 @@ class Plugin implements Integration {
 		$this->integrations[] = new WordPress_Plugin_Features( $plugins );
 		$this->integrations[] = new Schema( $option );
 		$this->integrations[] = new XML_Sitemaps( $option );
+		$this->integrations[] = new Indexables_Page( $option );
 		$this->integrations[] = new Feature_Toggler( $option );
 		$this->integrations[] = new Post_Types( $option );
 		$this->integrations[] = new Taxonomies( $option );

--- a/src/plugin.php
+++ b/src/plugin.php
@@ -9,6 +9,7 @@ use Yoast\WP\Test_Helper\WordPress_Plugins\WooCommerce_SEO;
 use Yoast\WP\Test_Helper\WordPress_Plugins\WordPress_Plugin;
 use Yoast\WP\Test_Helper\WordPress_Plugins\Yoast_SEO;
 use Yoast\WP\Test_Helper\WordPress_Plugins\Yoast_SEO_Premium;
+use Yoast\WP\SEO\Helpers\Indexables_Page_Helper;
 
 /**
  * Bootstrap for the entire plugin.
@@ -83,7 +84,9 @@ class Plugin implements Integration {
 		$this->integrations[] = new WordPress_Plugin_Features( $plugins );
 		$this->integrations[] = new Schema( $option );
 		$this->integrations[] = new XML_Sitemaps( $option );
-		$this->integrations[] = new Indexables_Page( $option );
+		if ( \class_exists( Indexables_Page_Helper::class ) ) {
+			$this->integrations[] = new Indexables_Page( $option );
+		}
 		$this->integrations[] = new Feature_Toggler( $option );
 		$this->integrations[] = new Post_Types( $option );
 		$this->integrations[] = new Taxonomies( $option );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds option to overwrite the default thresholds of the indexables page.

## Relevant technical choices:

* None

## Milestone

* [X] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Open the test helper and set the post threshold to 2000 (or more if you have more than 2000 posts) and save.
* Open the indexables page and you should now see `Start writing content!` and the reading tips.

* Open the test helper and set the post threshold to 1 and the amount of analyzed posts to 100 %. 
* Make sure you have 1 post that is not indexed. If needed disable yoast seo and create a post. Then reenable everything.
* Now reindex your content with the Start SEO optimization button in the setting or FTC (you may found it's already complete because of the background indexing)
* Open the indexables page and you should now see `Posts and pages without a focus keyphrase`

* Open the test helper and set the amount of analyzed posts to 1%.
* Open the indexables page and you should now see the indexables content.
* Downgrade Yoast SEO to 19.6 or lower
* visit the Test Helper and check that you can't find any indexables page section, and you don't get any errors.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

Fixes #
PC-529