### PR TITLE
PC-577 Make the schema endpoint work when there's no canonical

### DIFF
--- a/src/schema.php
+++ b/src/schema.php
@@ -74,13 +74,16 @@ class Schema implements Integration {
 	public function send_json_ld() {
 		global $wp_query;
 
-		$url = \YoastSEO()->meta->for_current_page()->canonical;
-		if ( empty( $url ) || ! isset( $wp_query->query_vars['schema'] ) ) {
+		if ( ! isset( $wp_query->query_vars['schema'] ) ) {
 			return;
 		}
 
 		\header( 'Content-Type: application/ld+json' );
-		\header( 'Link: <' . $url . '>; rel="canonical"' );
+		$url = \YoastSEO()->meta->for_current_page()->canonical;
+		if ( ! empty( $url ) ) {
+			\header( 'Link: <' . $url . '>; rel="canonical"' );
+		}
+
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- This is our self generated Schema, no need for escaping.
 		echo WPSEO_Utils::format_json_encode( \YoastSEO()->meta->for_current_page()->schema );
 		exit;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the schema endpoint would not work when there's no canonical.

## Relevant technical choices:

*

## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Recheck the [original PR](https://github.com/Yoast/yoast-test-helper/pull/154)
* Check that the `/schema` endpoint works for all the pages, in particular:
   * on search results pages
   * on the 404 page
   * on Date/Author/Taxonomy/Post type archives

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

