### PR TITLE
PC-579 Add feature toggle for the new settings UI

### DIFF
--- a/src/feature-toggler.php
+++ b/src/feature-toggler.php
@@ -58,10 +58,6 @@ class Feature_Toggler implements Integration {
 	 * @return string The HTML to use to render the controls.
 	 */
 	public function get_controls() {
-//		if ( $this->features === [] ) {
-//			return '';
-//		}
-
 		$fields = '';
 
 		$fields .= Form_Presenter::create_checkbox(

--- a/src/feature-toggler.php
+++ b/src/feature-toggler.php
@@ -62,7 +62,6 @@ class Feature_Toggler implements Integration {
 
 		$fields .= Form_Presenter::create_checkbox(
 			'enable_new_ui',
-			/* translators: %s expands to the label. */
 			\sprintf( \__( 'Enable the new Settings UI', 'yoast-test-helper' ) ),
 			$this->option->get( 'enable_new_ui' )
 		);

--- a/src/feature-toggler.php
+++ b/src/feature-toggler.php
@@ -44,11 +44,7 @@ class Feature_Toggler implements Integration {
 		);
 
 		if ( $this->option->get( 'enable_new_ui' ) === true ) {
-			if ( \defined( 'YOAST_SEO_NEW_SETTINGS_UI' ) ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- The prefix matches that of Yoast SEO, where this flag belongs.
-				return;
-			}
-
-			\define( 'YOAST_SEO_NEW_SETTINGS_UI', true ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- The prefix matches that of Yoast SEO, where this flag belongs.
+			\add_action( 'init', [ $this, 'enable_new_ui_feature_flag' ], 1 );
 		}
 	}
 
@@ -112,5 +108,16 @@ class Feature_Toggler implements Integration {
 		}
 
 		return $feature_array;
+	}
+
+	/**
+	 * Enables the feature flag for the new settings UI.
+	 */
+	public function enable_new_ui_feature_flag() {
+		if ( \defined( 'YOAST_SEO_NEW_SETTINGS_UI' ) ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- The prefix matches that of Yoast SEO, where this flag belongs.
+			return;
+		}
+
+		\define( 'YOAST_SEO_NEW_SETTINGS_UI', true ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- The prefix matches that of Yoast SEO, where this flag belongs.
 	}
 }

--- a/src/feature-toggler.php
+++ b/src/feature-toggler.php
@@ -42,6 +42,14 @@ class Feature_Toggler implements Integration {
 			'admin_post_yoast_seo_feature_toggler',
 			[ $this, 'handle_submit' ]
 		);
+
+		if ( $this->option->get( 'enable_new_ui' ) === true ) {
+			if ( \defined( 'YOAST_SEO_NEW_SETTINGS_UI' ) ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- The prefix matches that of Yoast SEO, where this flag belongs.
+				return;
+			}
+
+			\define( 'YOAST_SEO_NEW_SETTINGS_UI', true ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- The prefix matches that of Yoast SEO, where this flag belongs.
+		}
 	}
 
 	/**
@@ -50,11 +58,18 @@ class Feature_Toggler implements Integration {
 	 * @return string The HTML to use to render the controls.
 	 */
 	public function get_controls() {
-		if ( $this->features === [] ) {
-			return '';
-		}
+//		if ( $this->features === [] ) {
+//			return '';
+//		}
 
 		$fields = '';
+
+		$fields .= Form_Presenter::create_checkbox(
+			'enable_new_ui',
+			/* translators: %s expands to the label. */
+			\sprintf( \__( 'Enable the new Settings UI', 'yoast-test-helper' ) ),
+			$this->option->get( 'enable_new_ui' )
+		);
 
 		foreach ( $this->features as $feature => $label ) {
 			$key     = 'feature_toggle_' . $feature;
@@ -81,6 +96,8 @@ class Feature_Toggler implements Integration {
 				$this->option->set( $key, isset( $_POST[ $key ] ) );
 			}
 		}
+
+		$this->option->set( 'enable_new_ui', isset( $_POST['enable_new_ui'] ) );
 
 		\wp_safe_redirect( \self_admin_url( 'tools.php?page=' . \apply_filters( 'Yoast\WP\Test_Helper\admin_page', '' ) ) );
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds a feature toggle to enable the new settings UI.

## Relevant technical choices:

* ~Built on master so we can release quickly.~

## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* See that the new settings UI shows up.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.
