### PR TITLE
PC-581 indexables page feature toggle

### DIFF
--- a/src/feature-toggler.php
+++ b/src/feature-toggler.php
@@ -46,6 +46,10 @@ class Feature_Toggler implements Integration {
 		if ( $this->option->get( 'enable_new_ui' ) === true ) {
 			\add_action( 'init', [ $this, 'enable_new_ui_feature_flag' ], 1 );
 		}
+
+		if ( $this->option->get( 'enable_indexables_overview' ) === true ) {
+			\add_action( 'init', [ $this, 'enable_indexables_overview_feature_flag' ], 1 );
+		}
 	}
 
 	/**
@@ -60,6 +64,12 @@ class Feature_Toggler implements Integration {
 			'enable_new_ui',
 			\sprintf( \__( 'Enable the new Settings UI', 'yoast-test-helper' ) ),
 			$this->option->get( 'enable_new_ui' )
+		);
+
+		$fields .= Form_Presenter::create_checkbox(
+			'enable_indexables_overview',
+			\sprintf( \__( 'Enable the Indexables overview', 'yoast-test-helper' ) ),
+			$this->option->get( 'enable_indexables_overview' )
 		);
 
 		foreach ( $this->features as $feature => $label ) {
@@ -89,6 +99,7 @@ class Feature_Toggler implements Integration {
 		}
 
 		$this->option->set( 'enable_new_ui', isset( $_POST['enable_new_ui'] ) );
+		$this->option->set( 'enable_indexables_overview', isset( $_POST['enable_indexables_overview'] ) );
 
 		\wp_safe_redirect( \self_admin_url( 'tools.php?page=' . \apply_filters( 'Yoast\WP\Test_Helper\admin_page', '' ) ) );
 	}
@@ -119,5 +130,16 @@ class Feature_Toggler implements Integration {
 		}
 
 		\define( 'YOAST_SEO_NEW_SETTINGS_UI', true ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- The prefix matches that of Yoast SEO, where this flag belongs.
+	}
+
+	/**
+	 * Enables the feature flag for the Indexables overview.
+	 */
+	public function enable_indexables_overview_feature_flag() {
+		if ( \defined( 'YOAST_SEO_INDEXABLES_PAGE' ) ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- The prefix matches that of Yoast SEO, where this flag belongs.
+			return;
+		}
+
+		\define( 'YOAST_SEO_INDEXABLES_PAGE', true ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- The prefix matches that of Yoast SEO, where this flag belongs.
 	}
 }

--- a/src/indexables-page.php
+++ b/src/indexables-page.php
@@ -71,7 +71,7 @@ class Indexables_Page implements Integration {
 	 * @return string The HTML to use to render the controls.
 	 */
 	public function get_controls() {
-		if ( ! $this->option->get( 'enable_indexables_overview' ) ) {
+		if ( ! \defined( 'YOAST_SEO_INDEXABLES_PAGE' ) || YOAST_SEO_INDEXABLES_PAGE !== true ) {
 			return '';
 		}
 

--- a/src/indexables-page.php
+++ b/src/indexables-page.php
@@ -71,6 +71,10 @@ class Indexables_Page implements Integration {
 	 * @return string The HTML to use to render the controls.
 	 */
 	public function get_controls() {
+		if ( ! $this->option->get( 'enable_indexables_overview' ) ) {
+			return '';
+		}
+
 		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Using WPSEO hook.
 		$placeholder_thresholds = \apply_filters( 'wpseo_posts_threshold', Indexables_Page_Helper::POSTS_THRESHOLD );
 		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Using WPSEO hook.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds a feature toggle to enable the indexables overview.

## Relevant technical choices:

*

## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* test with the latest Free release branch
* make sure you have no `define( 'YOAST_SEO_INDEXABLES_PAGE', true )` anywhere
* visit the Yoast Test Helper page
* see that you can see a `Enable the Indexables overview` checkbox, but no `Indexables overview thresholds` section
* check that you can't see the indexables overview
* visit the Yoast Test Helper page
* check the  `Enable the Indexables overview` checkbox and save
* check that you can see the  `Indexables overview thresholds` section
* check that you can see the indexables overview now

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

Fixes [PC-581]


[PC-581]: https://yoast.atlassian.net/browse/PC-581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ