### PR TITLE
DUPP-670 Add null check to wp_parse_url for PHP 8.1 compatibility

### DIFF
--- a/src/domain-dropdown.php
+++ b/src/domain-dropdown.php
@@ -118,6 +118,10 @@ class Domain_Dropdown implements Integration {
 		$url_host = \wp_parse_url( $url, \PHP_URL_HOST );
 		$new_host = \wp_parse_url( $domain, \PHP_URL_HOST );
 
+        if ( $new_host === false || \is_null( $new_host ) ) {
+            $new_host = '';
+        }
+
 		if ( $url_host === 'my.yoast.com' ) {
 			$host = isset( $headers['Host'] ) ? $headers['Host'] : $new_host;
 			$url  = \str_replace( 'https://' . $url_host, $domain, $url );

--- a/src/domain-dropdown.php
+++ b/src/domain-dropdown.php
@@ -118,7 +118,7 @@ class Domain_Dropdown implements Integration {
 		$url_host = \wp_parse_url( $url, \PHP_URL_HOST );
 		$new_host = \wp_parse_url( $domain, \PHP_URL_HOST );
 
-		if ( $new_host === false || \is_null( $new_host ) ) {
+		if ( $new_host === false || $new_host === null ) {
 			$new_host = '';
 		}
 

--- a/src/domain-dropdown.php
+++ b/src/domain-dropdown.php
@@ -118,9 +118,9 @@ class Domain_Dropdown implements Integration {
 		$url_host = \wp_parse_url( $url, \PHP_URL_HOST );
 		$new_host = \wp_parse_url( $domain, \PHP_URL_HOST );
 
-        if ( $new_host === false || \is_null( $new_host ) ) {
-            $new_host = '';
-        }
+		if ( $new_host === false || \is_null( $new_host ) ) {
+			$new_host = '';
+		}
 
 		if ( $url_host === 'my.yoast.com' ) {
 			$host = isset( $headers['Host'] ) ? $headers['Host'] : $new_host;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Improves PHP 8.1 compatibility for `replace_domain` function.

## Relevant technical choices:

*

## Milestone

* [ ] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* NA

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

Fixes #
