### PR TITLE
Drop compatibility with PHP 5.6, 7.0 and 7.1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 5.6
+          php-version: 7.2
           coverage: none
 
       # This action also handles the caching of the Yarn dependencies.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         # Lint against the highest/lowest supported versions of each PHP major.
         # And also do a run against "nightly" (the current dev version of PHP).
-        php_version: ['5.6', '7.0', '7.4', '8.0', '8.1', '8.2']
+        php_version: ['7.2', '7.4', '8.0', '8.1', '8.2']
 
     name: "Lint: PHP ${{ matrix.php_version }}"
 

--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,14 @@
   },
   "config": {
     "platform": {
-      "php": "5.6.20"
+      "php": "7.2.5"
     },
     "allow-plugins": {
       "dealerdirect/phpcodesniffer-composer-installer": true
     }
   },
   "require": {
-    "php": "^5.6.20 || ^7.0 || ^8.0"
+    "php": "^7.2.5 || ^8.0"
   },
   "require-dev": {
     "yoast/yoastcs": "^2.3.0"

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "php": "^7.2.5 || ^8.0"
   },
   "require-dev": {
-    "yoast/yoastcs": "^2.3.0"
+    "yoast/yoastcs": "^2.3.1"
   },
   "scripts": {
     "lint": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f7974ebf7b57e2b434cd2d91a08b6824",
+    "content-hash": "3f4d04d19f13a6ea6f0bb41f6b30d3ff",
     "packages": [],
     "packages-dev": [
         {
@@ -587,11 +587,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^5.6.20 || ^7.0 || ^8.0"
+        "php": "^7.2.5 || ^8.0"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "5.6.20"
+        "php": "7.2.5"
     },
     "plugin-api-version": "2.2.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3f4d04d19f13a6ea6f0bb41f6b30d3ff",
+    "content-hash": "772f3b8dd0c3afe8ed1cf04383ee2b68",
     "packages": [],
     "packages-dev": [
         {
@@ -419,16 +419,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.7.1",
+            "version": "3.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "shasum": ""
             },
             "require": {
@@ -464,14 +464,15 @@
             "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
-                "standards"
+                "standards",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2022-06-18T07:21:10+00:00"
+            "time": "2023-02-22T23:07:41+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -526,16 +527,16 @@
         },
         {
             "name": "yoast/yoastcs",
-            "version": "2.3.0",
+            "version": "2.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/yoastcs.git",
-                "reference": "b52b3f1f08e303d3c261bc522a36b2b63618fea5"
+                "reference": "8ed5af5ce8ef362a88cfe67faf0d9e4503ca7470"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/yoastcs/zipball/b52b3f1f08e303d3c261bc522a36b2b63618fea5",
-                "reference": "b52b3f1f08e303d3c261bc522a36b2b63618fea5",
+                "url": "https://api.github.com/repos/Yoast/yoastcs/zipball/8ed5af5ce8ef362a88cfe67faf0d9e4503ca7470",
+                "reference": "8ed5af5ce8ef362a88cfe67faf0d9e4503ca7470",
                 "shasum": ""
             },
             "require": {
@@ -544,7 +545,7 @@
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
                 "php-parallel-lint/php-parallel-lint": "^1.3.2",
                 "phpcompatibility/phpcompatibility-wp": "^2.1.4",
-                "squizlabs/php_codesniffer": "^3.7.1",
+                "squizlabs/php_codesniffer": "^3.7.2",
                 "wp-coding-standards/wpcs": "^2.3.0"
             },
             "require-dev": {
@@ -578,7 +579,7 @@
                 "issues": "https://github.com/Yoast/yoastcs/issues",
                 "source": "https://github.com/Yoast/yoastcs"
             },
-            "time": "2023-01-09T11:26:18+00:00"
+            "time": "2023-03-09T10:10:51+00:00"
         }
     ],
     "aliases": [],
@@ -593,5 +594,5 @@
     "platform-overrides": {
         "php": "7.2.5"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/languages/yoast-test-helper.pot
+++ b/languages/yoast-test-helper.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Yoast Test Helper 1.18-RC2\n"
 "Report-Msgid-Bugs-To: https://github.com/yoast/yoast-test-helper/issues\n"
-"POT-Creation-Date: 2023-03-07 14:10:33+00:00\n"
+"POT-Creation-Date: 2023-03-20 10:58:39+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -346,7 +346,7 @@ msgstr ""
 #: src/wordpress-plugins/video-seo.php:81
 #: src/wordpress-plugins/woocommerce-seo.php:83
 #: src/wordpress-plugins/yoast-seo-premium.php:83
-#: src/wordpress-plugins/yoast-seo.php:150
+#: src/wordpress-plugins/yoast-seo.php:146
 msgid "not active"
 msgstr ""
 
@@ -400,10 +400,6 @@ msgstr ""
 
 #: src/wordpress-plugins/yoast-seo.php:86
 msgid "Cornerstone flags"
-msgstr ""
-
-#: src/wordpress-plugins/yoast-seo.php:87
-msgid "Ignored indexables"
 msgstr ""
 
 #: src/xml-sitemaps.php:69

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: Yoast, Yoast SEO, development
 Requires at least: 6.0
 Tested up to: 6.1
 Stable tag: 1.18-RC2
-Requires PHP: 5.6
+Requires PHP: 7.2.5
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/yoast-test-helper.php
+++ b/yoast-test-helper.php
@@ -16,6 +16,8 @@
  * Text Domain: yoast-test-helper
  * Domain Path: /languages/
  * License:     GPL v3
+ * Requires at least: 6.0
+ * Requires PHP: 7.2.5
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*  Fixes https://github.com/Yoast/wordpress-seo/issues/19801

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Drops compatibility with PHP 5.6, 7.0 and 7.1.


## Relevant technical choices:
 
* Note that this addon doesn't have any requirement to Yoast SEO so we won't need to update any reference to the Free feature branch.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Verify the GH actions pass
* install on a PHP 5.6 environment
* visit the Plugins page
* see that you get the same message and you can't activate the plugin, as it happens here for Free and Premium:
![Screenshot 2023-03-03 at 13-28-32 Plugins ‹ rodeo-polo-nimi instawp xyz — WordPress](https://user-images.githubusercontent.com/15989132/222720342-ef651e58-de59-4cca-a2f0-60671cb87429.png)
* the same should happen with 7.0 and 7.1

**note**: the above may be tricky to test. I can see 5.6 as a choice in Local by Flywheel, but I know it's not the case for others (and I can see 7.0 an 7.1 are not available - neither 7.2 actually)
I tried on Instawp, where you have the full choice of PHP versions, but when uploading the artifact I got:
![Screenshot 2023-03-03 at 11-27-45 Upload Plugin ‹ rodeo-polo-nimi instawp xyz — WordPress](https://user-images.githubusercontent.com/15989132/222696992-5ba1bf92-2cb5-42cb-a19c-a98a01024141.png)
which is also a nice thing to check, actually.

So a way could be:
- start a 7.2 site on instawp
- upload the artifact but  **don't activate it**
- switch to 5.6
- check that  you get the same message above and you can't activate the plugin
- switch to 7.0 an 7.1
- the same should happen

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/wordpress-seo/issues/19801
