### PR TITLE
Remove the Schema blocks checkbox

### DIFF
--- a/src/schema.php
+++ b/src/schema.php
@@ -33,10 +33,6 @@ class Schema implements Integration {
 			\add_filter( 'wpseo_debug_json_data', [ $this, 'replace_domain' ] );
 		}
 
-		if ( $this->option->get( 'enable_structured_data_blocks' ) === true ) {
-			\add_action( 'init', [ $this, 'enable_feature_flag' ] );
-		}
-
 		if ( $this->option->get( 'enable_schema_endpoint' ) === true ) {
 			\add_action( 'template_redirect', [ $this, 'send_json_ld' ] );
 			\add_action( 'init', [ $this, 'init_rewrite' ] );
@@ -109,12 +105,6 @@ class Schema implements Integration {
 			$this->option->get( 'enable_schema_endpoint' )
 		);
 
-		$output .= Form_Presenter::create_checkbox(
-			'enable_structured_data_blocks',
-			\esc_html__( 'Enable the feature flag for the structured data blocks.', 'yoast-test-helper' ),
-			$this->option->get( 'enable_structured_data_blocks' )
-		);
-
 		$select_options = [
 			'none' => \esc_html__( 'Don\'t influence', 'yoast-test-helper' ),
 			'show' => \esc_html__( 'Always include', 'yoast-test-helper' ),
@@ -147,7 +137,6 @@ class Schema implements Integration {
 		if ( \check_admin_referer( 'yoast_seo_test_schema' ) !== false ) {
 			$this->option->set( 'replace_schema_domain', isset( $_POST['replace_schema_domain'] ) );
 			$this->option->set( 'enable_schema_endpoint', isset( $_POST['enable_schema_endpoint'] ) );
-			$this->option->set( 'enable_structured_data_blocks', isset( $_POST['enable_structured_data_blocks'] ) );
 		}
 
 		$is_needed_breadcrumb = $this->validate_submit( \filter_input( \INPUT_POST, 'is_needed_breadcrumb' ) );
@@ -190,17 +179,6 @@ class Schema implements Integration {
 		}
 
 		return $this->array_value_str_replace( $source, $target, $data );
-	}
-
-	/**
-	 * Enables the feature flag for the structured data blocks.
-	 */
-	public function enable_feature_flag() {
-		if ( \defined( 'YOAST_SEO_SCHEMA_BLOCKS' ) ) { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- The prefix matches that of Yoast SEO, where this flag belongs.
-			return;
-		}
-
-		\define( 'YOAST_SEO_SCHEMA_BLOCKS', true ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- The prefix matches that of Yoast SEO, where this flag belongs.
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Removes the checkbox to enable the feature flag for the structured data blocks.

## Relevant technical choices:

* 

## Milestone

* [ ] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Check that the "Enable the feature flag for the structured data blocks." checkbox in the Schema section is not present anymore.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

Fixes https://github.com/Yoast/wordpress-seo/issues/19919
