### PR TITLE
191 test helper php 81 improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /vendor/
 /node_modules/
 .idea/
+.vscode/
 artifact.zip
 /artifact/
 yarn-error.log
@@ -17,5 +18,3 @@ phpcs.xml
 [Dd]esktop.ini
 *.DS_store
 .DS_store?
-
-.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ phpcs.xml
 [Dd]esktop.ini
 *.DS_store
 .DS_store?
+
+.vscode/

--- a/src/domain-dropdown.php
+++ b/src/domain-dropdown.php
@@ -71,7 +71,7 @@ class Domain_Dropdown implements Integration {
 	 */
 	public function handle_submit() {
 
-		if ( ! \check_admin_referer( 'yoast_seo_domain_dropdown' ) &&  !isset( $_POST['myyoast_test_domain'] ) ) {
+		if ( ! \check_admin_referer( 'yoast_seo_domain_dropdown' ) && ! isset( $_POST['myyoast_test_domain'] ) ) {
 			return;
 		}
 

--- a/src/domain-dropdown.php
+++ b/src/domain-dropdown.php
@@ -70,7 +70,6 @@ class Domain_Dropdown implements Integration {
 	 * @return void
 	 */
 	public function handle_submit() {
-
 		if ( ! \check_admin_referer( 'yoast_seo_domain_dropdown' ) && ! isset( $_POST['myyoast_test_domain'] ) ) {
 			return;
 		}

--- a/src/domain-dropdown.php
+++ b/src/domain-dropdown.php
@@ -70,9 +70,14 @@ class Domain_Dropdown implements Integration {
 	 * @return void
 	 */
 	public function handle_submit() {
-		if ( \check_admin_referer( 'yoast_seo_domain_dropdown' ) !== false ) {
-			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- This deprecation will be addressed later.
-			$this->option->set( 'myyoast_test_domain', \filter_input( \INPUT_POST, 'myyoast_test_domain', @\FILTER_SANITIZE_STRING ) );
+
+		if ( ! \check_admin_referer( 'yoast_seo_domain_dropdown' ) &&  !isset( $_POST['myyoast_test_domain'] ) ) {
+			return;
+		}
+
+		if ( isset( $_POST['myyoast_test_domain'] ) && \is_string( $_POST['myyoast_test_domain'] ) ) {
+			$myyoast_test_domain = \sanitize_text_field( \wp_unslash( $_POST['myyoast_test_domain'] ) );
+			$this->option->set( 'myyoast_test_domain', $myyoast_test_domain );
 		}
 
 		\wp_safe_redirect( \self_admin_url( 'tools.php?page=' . \apply_filters( 'Yoast\WP\Test_Helper\admin_page', '' ) ) );

--- a/src/downgrader.php
+++ b/src/downgrader.php
@@ -54,11 +54,11 @@ class Downgrader implements Integration {
 		if ( ! \check_admin_referer( 'yoast_rollback_control' ) ) {
 			return;
 		}
-		if ( ! isset( $_POST['target_version'] ) ) {
+		if ( ! isset( $_POST['target_version'] ) || ! \is_string( $_POST['target_version'] ) ) {
 			return;
 		}
 
-		$target_version = ( isset( $_POST['target_version'] ) ) ? \sanitize_text_field( \wp_unslash( $_POST['target_version'] ) ) : null;
+		$target_version = \sanitize_text_field( \wp_unslash( $_POST['target_version'] ) );
 
 		try {
 			$this->downgrade( $target_version );

--- a/src/downgrader.php
+++ b/src/downgrader.php
@@ -58,7 +58,8 @@ class Downgrader implements Integration {
 			return;
 		}
 
-		$target_version = \filter_var( \wp_unslash( $_POST['target_version'] ) );
+		$target_version = ( isset( $_POST['target_version'] ) ) ? \sanitize_text_field( \wp_unslash( $_POST['target_version'] ) ) : null;
+
 		try {
 			$this->downgrade( $target_version );
 			\do_action(

--- a/src/inline-script.php
+++ b/src/inline-script.php
@@ -82,7 +82,7 @@ class Inline_Script implements Integration {
 		if ( \check_admin_referer( 'yoast_seo_test_inline_script' ) !== false ) {
 			$this->option->set( 'add_inline_script', isset( $_POST['add_inline_script'] ) );
 
-			if ( isset( $_POST['inline_script_handle'] ) && is_string( $_POST['inline_script_handle'] ) ) {
+			if ( isset( $_POST['inline_script_handle'] ) && \is_string( $_POST['inline_script_handle'] ) ) {
 				$inline_script_handle = \sanitize_text_field( \wp_unslash( $_POST['inline_script_handle'] ) );
 				$this->option->set( 'inline_script_handle', $inline_script_handle );
 			}

--- a/src/inline-script.php
+++ b/src/inline-script.php
@@ -74,7 +74,7 @@ class Inline_Script implements Integration {
 	}
 
 	/**
-	 * Handles the form submit.
+	 * Handles the form submit for adding inline script.
 	 *
 	 * @return void
 	 */

--- a/src/inline-script.php
+++ b/src/inline-script.php
@@ -86,7 +86,7 @@ class Inline_Script implements Integration {
 				$inline_script_handle = \sanitize_text_field( \wp_unslash( $_POST['inline_script_handle'] ) );
 				$this->option->set( 'inline_script_handle', $inline_script_handle );
 			}
-			if ( isset( $_POST['inline_script'] ) && is_string( $_POST['inline_script'] ) ) {
+			if ( isset( $_POST['inline_script'] ) && \is_string( $_POST['inline_script'] ) ) {
 				$inline_script = \sanitize_text_field( \wp_unslash( $_POST['inline_script'] ) );
 				$this->option->set( 'inline_script', $inline_script );
 			}

--- a/src/inline-script.php
+++ b/src/inline-script.php
@@ -81,10 +81,15 @@ class Inline_Script implements Integration {
 	public function handle_submit() {
 		if ( \check_admin_referer( 'yoast_seo_test_inline_script' ) !== false ) {
 			$this->option->set( 'add_inline_script', isset( $_POST['add_inline_script'] ) );
-			// phpcs:disable WordPress.PHP.NoSilencedErrors.Discouraged -- These deprecations will be addressed later.
-			$this->option->set( 'inline_script_handle', \filter_input( \INPUT_POST, 'inline_script_handle', @\FILTER_SANITIZE_STRING ) );
-			$this->option->set( 'inline_script', \filter_input( \INPUT_POST, 'inline_script', @\FILTER_SANITIZE_STRING ) );
-			// phpcs:enable
+
+			if ( isset( $_POST['inline_script_handle'] ) && is_string( $_POST['inline_script_handle'] ) ) {
+				$inline_script_handle = \sanitize_text_field( \wp_unslash( $_POST['inline_script_handle'] ) );
+				$this->option->set( 'inline_script_handle', $inline_script_handle );
+			}
+			if ( isset( $_POST['inline_script'] ) && is_string( $_POST['inline_script'] ) ) {
+				$inline_script = \sanitize_text_field( \wp_unslash( $_POST['inline_script'] ) );
+				$this->option->set( 'inline_script', $inline_script );
+			}
 		}
 
 		\wp_safe_redirect( \self_admin_url( 'tools.php?page=' . \apply_filters( 'Yoast\WP\Test_Helper\admin_page', '' ) ) );

--- a/src/plugin-toggler.php
+++ b/src/plugin-toggler.php
@@ -177,11 +177,13 @@ class Plugin_Toggler implements Integration {
 		$response = [];
 
 		// If nonce is valid.
-		if ( $this->verify_nonce() ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- The nonce is verified in a different method.
+		if ( $this->verify_nonce() && isset( $_GET['group'] ) && is_string( $_GET['group'] && isset( $_GET['plugin'] ) && is_string( $_GET['plugin'] ) ) ) {
+
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- The nonce is verified above.
-			$group = ( isset( $_GET['group'] ) ) ? \sanitize_text_field( \wp_unslash( $_GET['group'] ) ) : null;
+			$group = \sanitize_text_field( \wp_unslash( $_GET['group'] ) );
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- The nonce is verified above.
-			$plugin = ( isset( $_GET['plugin'] ) ) ? \sanitize_text_field( \wp_unslash( $_GET['plugin'] ) ) : null;
+			$plugin = \sanitize_text_field( \wp_unslash( $_GET['plugin'] ) );
 
 			// First deactivate the current plugin.
 			$this->deactivate_plugin_group( $group );

--- a/src/plugin-toggler.php
+++ b/src/plugin-toggler.php
@@ -427,7 +427,7 @@ class Plugin_Toggler implements Integration {
 	private function verify_nonce() {
 
 		// If nonce is valid return true.
-		if ( isset( $_GET['ajax_nonce'] ) && \wp_verify_nonce( $ajax_nonce, 'yoast-plugin-toggle' ) ) {
+		if ( isset( $_GET['ajax_nonce'] ) && \wp_verify_nonce( $_GET['ajax_nonce'], 'yoast-plugin-toggle' ) ) {
 			return true;
 		}
 	}

--- a/src/plugin-toggler.php
+++ b/src/plugin-toggler.php
@@ -178,8 +178,10 @@ class Plugin_Toggler implements Integration {
 
 		// If nonce is valid.
 		if ( $this->verify_nonce() ) {
-			$group  = \filter_input( \INPUT_GET, 'group' );
-			$plugin = \filter_input( \INPUT_GET, 'plugin' );
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- The nonce is verified above.
+			$group = ( isset( $_GET['group'] ) ) ? \sanitize_text_field( \wp_unslash( $_GET['group'] ) ) : null;
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- The nonce is verified above.
+			$plugin = ( isset( $_GET['plugin'] ) ) ? \sanitize_text_field( \wp_unslash( $_GET['plugin'] ) ) : null;
 
 			// First deactivate the current plugin.
 			$this->deactivate_plugin_group( $group );
@@ -422,7 +424,7 @@ class Plugin_Toggler implements Integration {
 	 */
 	private function verify_nonce() {
 		// Get the nonce value.
-		$ajax_nonce = \filter_input( \INPUT_GET, 'ajax_nonce' );
+		$ajax_nonce = isset( $_GET['ajax_nonce'] ) ? sanitize_text_field( wp_unslash( $_GET['ajax_nonce'] ) ) : null;
 
 		// If nonce is valid return true.
 		if ( \wp_verify_nonce( $ajax_nonce, 'yoast-plugin-toggle' ) ) {

--- a/src/plugin-toggler.php
+++ b/src/plugin-toggler.php
@@ -178,7 +178,7 @@ class Plugin_Toggler implements Integration {
 
 		// If nonce is valid.
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- The nonce is verified in a different method.
-		if ( $this->verify_nonce() && isset( $_GET['group'] ) && is_string( $_GET['group'] && isset( $_GET['plugin'] ) && is_string( $_GET['plugin'] ) ) ) {
+		if ( $this->verify_nonce() && isset( $_GET['group'] ) && \is_string( $_GET['group'] && isset( $_GET['plugin'] ) && \is_string( $_GET['plugin'] ) ) ) {
 
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- The nonce is verified above.
 			$group = \sanitize_text_field( \wp_unslash( $_GET['group'] ) );

--- a/src/plugin-toggler.php
+++ b/src/plugin-toggler.php
@@ -425,11 +425,9 @@ class Plugin_Toggler implements Integration {
 	 * @return bool True if verified.
 	 */
 	private function verify_nonce() {
-		// Get the nonce value.
-		$ajax_nonce = isset( $_GET['ajax_nonce'] ) ? sanitize_text_field( wp_unslash( $_GET['ajax_nonce'] ) ) : null;
 
 		// If nonce is valid return true.
-		if ( \wp_verify_nonce( $ajax_nonce, 'yoast-plugin-toggle' ) ) {
+		if ( isset( $_GET['ajax_nonce'] ) && \wp_verify_nonce( $ajax_nonce, 'yoast-plugin-toggle' ) ) {
 			return true;
 		}
 	}

--- a/src/plugin-toggler.php
+++ b/src/plugin-toggler.php
@@ -427,6 +427,7 @@ class Plugin_Toggler implements Integration {
 	private function verify_nonce() {
 
 		// If nonce is valid return true.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- The nonce does not need sanitization.
 		if ( isset( $_GET['ajax_nonce'] ) && \wp_verify_nonce( $_GET['ajax_nonce'], 'yoast-plugin-toggle' ) ) {
 			return true;
 		}

--- a/src/schema.php
+++ b/src/schema.php
@@ -142,11 +142,17 @@ class Schema implements Integration {
 			$this->option->set( 'enable_schema_endpoint', isset( $_POST['enable_schema_endpoint'] ) );
 		}
 
-		$is_needed_breadcrumb = $this->validate_submit( \filter_input( \INPUT_POST, 'is_needed_breadcrumb' ) );
-		$is_needed_webpage    = $this->validate_submit( \filter_input( \INPUT_POST, 'is_needed_webpage' ) );
+		if ( isset( $_POST['is_needed_breadcrumb'] ) ) {
+			$is_needed_breadcrumb           = \sanitize_text_field( \wp_unslash( $_POST['is_needed_breadcrumb'] ) );
+			$validated_is_needed_breadcrumb = $this->validate_submit( $is_needed_breadcrumb );
+			$this->option->set( 'is_needed_breadcrumb', $validated_is_needed_breadcrumb );
+		}
 
-		$this->option->set( 'is_needed_breadcrumb', $is_needed_breadcrumb );
-		$this->option->set( 'is_needed_webpage', $is_needed_webpage );
+		if ( isset( $_POST['is_needed_webpage'] ) ) {
+			$is_needed_webpage           = \sanitize_text_field( \wp_unslash( $_POST['is_needed_webpage'] ) );
+			$validated_is_needed_webpage = $this->validate_submit( $is_needed_webpage );
+			$this->option->set( 'is_needed_webpage', $validated_is_needed_webpage );
+		}
 
 		\wp_safe_redirect( \self_admin_url( 'tools.php?page=' . \apply_filters( 'Yoast\WP\Test_Helper\admin_page', '' ) ) );
 	}

--- a/src/schema.php
+++ b/src/schema.php
@@ -143,14 +143,14 @@ class Schema implements Integration {
 		}
 
 		if ( isset( $_POST['is_needed_breadcrumb'] ) ) {
-			$is_needed_breadcrumb           = \sanitize_text_field( \wp_unslash( $_POST['is_needed_breadcrumb'] ) );
-			$validated_is_needed_breadcrumb = $this->validate_submit( $is_needed_breadcrumb );
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- validation is done in validate_submit.
+			$validated_is_needed_breadcrumb = $this->validate_submit( $_POST['is_needed_breadcrumb'] );
 			$this->option->set( 'is_needed_breadcrumb', $validated_is_needed_breadcrumb );
 		}
 
 		if ( isset( $_POST['is_needed_webpage'] ) ) {
-			$is_needed_webpage           = \sanitize_text_field( \wp_unslash( $_POST['is_needed_webpage'] ) );
-			$validated_is_needed_webpage = $this->validate_submit( $is_needed_webpage );
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- validation is done in validate_submit.
+			$validated_is_needed_webpage = $this->validate_submit( $_POST['is_needed_webpage'] );
 			$this->option->set( 'is_needed_webpage', $validated_is_needed_webpage );
 		}
 

--- a/src/xml-sitemaps.php
+++ b/src/xml-sitemaps.php
@@ -85,7 +85,7 @@ class XML_Sitemaps implements Integration {
 			$this->option->set( 'disable_xml_sitemap_cache', isset( $_POST['disable_xml_sitemap_cache'] ) );
 			$xml_sitemap_entries = null;
 			if ( isset( $_POST['xml_sitemap_entries'] ) ) {
-				$xml_sitemap_entries = \filter_input( \INPUT_POST, 'xml_sitemap_entries', \FILTER_SANITIZE_NUMBER_INT );
+				$xml_sitemap_entries = \intval( \wp_unslash( $_POST['xml_sitemap_entries'] ) );
 			}
 			$this->option->set( 'xml_sitemap_entries', $xml_sitemap_entries );
 		}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Removes `filter_input` and `filter_var` for PHP 8.1.

## Relevant technical choices:

Go to `Tools`->`Yoast Test` and check the following:

**Domain dropdown**
* Go to `Domain dropdown` card and change to `local`.
* Refresh and check option is saved. 
* Restore to live and check it is saved.

**Downgrade Yoast SEO**
* Go to `Downgrade Yoast SEO` and add a previous version and save.
* Refresh and check version is saved.

**Inline script**
* Go to `Inline script` card and check the checkbox.
* Add to the `Script` box `console.log('test');` and save.
* Refresh and check it is saved.
* Clear `Script` box and disable the Inline script and save.
* Refresh and check it is saved.

**Plugin toggler**
* Go to `Plugin toggler` card and enable.
* Follow the test instructions [here](https://github.com/Yoast/yoast-test-helper/pull/32).

**Schema**
* Go to `Schema` card and select different option for `Influence the Breadcrumb Graph piece`.
* Select different option for `Influence the WebPage Graph piece` and save.
* Refresh and check it is saved.

**XML Sitemaps**
* Go to `XML Sitemaps` and check the checkbox.
* Refresh and check it is saved.



## Milestone

* [ ] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* 

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

Fixes #191 
