### PR TITLE
Switch to the newer key for the Local SEO version

### DIFF
--- a/src/wordpress-plugins/local-seo.php
+++ b/src/wordpress-plugins/local-seo.php
@@ -40,7 +40,7 @@ class Local_SEO implements WordPress_Plugin {
 	 * @return string The version key.
 	 */
 	public function get_version_key() {
-		return 'version';
+		return 'local_version';
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the DB version for Local SEO would not be updated correctly.

## Relevant technical choices:

* the key in `wpseo_local` storing the Local SEO version has changed from `version` to `local_version` since 12.3, but Test Helper was never adapted to reflect that.

## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Local SEO
* Use Test Helper to change the DB version for Local SEO to a previous version e.g. 14.9
* See that on reload the version is back to the actual one of the installed Local SEO (e.g. 15.0) because Local SEO has adjusted it.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

Fixes #
