### PR TITLE
Various small bug fixes

### DIFF
--- a/src/admin-notifications.php
+++ b/src/admin-notifications.php
@@ -20,7 +20,7 @@ class Admin_Notifications implements Integration {
 	 * @return void
 	 */
 	public function add_hooks() {
-		\add_action( 'Yoast\WP\Test_Helper\notification', [ $this, 'add_notification' ], 10, 2 );
+		\add_action( 'Yoast\WP\Test_Helper\notification', [ $this, 'add_notification' ] );
 		\add_action( 'Yoast\WP\Test_Helper\notifications', [ $this, 'display_notifications' ] );
 	}
 

--- a/src/admin-page.php
+++ b/src/admin-page.php
@@ -44,7 +44,7 @@ class Admin_Page implements Integration {
 		\wp_enqueue_style(
 			'yoast-test-admin-style',
 			\plugin_dir_url( \YOAST_TEST_HELPER_FILE ) . 'assets/css/admin.css',
-			null,
+			[],
 			\YOAST_TEST_HELPER_VERSION
 		);
 		\wp_enqueue_script( 'masonry' );

--- a/src/downgrader.php
+++ b/src/downgrader.php
@@ -151,7 +151,7 @@ class Downgrader implements Integration {
 				$adapter->remove_version( $version );
 				$adapter->commit_transaction();
 			} catch ( Exception $e ) {
-				$this->adapter->rollback_transaction();
+				$adapter->rollback_transaction();
 
 				throw new Exception(
 					\sprintf(

--- a/src/feature-toggler.php
+++ b/src/feature-toggler.php
@@ -36,7 +36,7 @@ class Feature_Toggler implements Integration {
 	 * @return void
 	 */
 	public function add_hooks() {
-		\add_action( 'wpseo_enable_feature', [ $this, 'enable_features' ] );
+		\add_filter( 'wpseo_enable_feature', [ $this, 'enable_features' ] );
 
 		\add_action(
 			'admin_post_yoast_seo_feature_toggler',

--- a/src/plugin-toggler.php
+++ b/src/plugin-toggler.php
@@ -394,7 +394,7 @@ class Plugin_Toggler implements Integration {
 		}
 
 		$plugin_path = $this->plugin_groups[ $group ][ $plugin ];
-		\activate_plugin( \plugin_basename( $plugin_path ), null, false, true );
+		\activate_plugin( \plugin_basename( $plugin_path ), '', false, true );
 	}
 
 	/**

--- a/src/plugin-toggler.php
+++ b/src/plugin-toggler.php
@@ -431,6 +431,8 @@ class Plugin_Toggler implements Integration {
 		if ( isset( $_GET['ajax_nonce'] ) && \wp_verify_nonce( $_GET['ajax_nonce'], 'yoast-plugin-toggle' ) ) {
 			return true;
 		}
+
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes some small bugs that could result in PHP notices/warnings/errors.

## Relevant technical choices:

### Admin_Notifications::add_notification(): bug fix

The `Admin_Notifications::add_notification()` method only expects one parameter, so no need to ask WP for 2.

### Downgrader::downgrade(): bug fix

The `$adapter` property does not exist. The `$adapter` local variable does.

### Feature_Toggler::add_hooks(): use the correct function

The `wpseo_enable_feature` hook is a filter, not an action.

### Plugin_Toggler::verify_nonce(): consistent return type

The return type is documented as `bool`, but the function contained a path which didn't return any value. Fixed now.

### Admin_Page::add_assets(): bug fix

The third (`$deps`) parameter for `wp_enqueue_style()` expects an array of strings, not `null`.

Ref: https://developer.wordpress.org/reference/functions/wp_enqueue_style/

### Plugin_Toggler::activate_plugin(): bug fix

The second (`$redirect`) parameter for `activate_plugin()` expects a string, not `null`.

Ref: https://developer.wordpress.org/reference/functions/activate_plugin/

## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

only this part can be tested: `Downgrader::downgrade(): bug fix`:
- Install and activate the latest Free and Test Helper
- edit the Free source file `lib/migrations/adapter.php` at line 1049 from 
```
		if ( $this->in_transaction === false ) {
```
to
```
		if ( true || $this->in_transaction === false ) {
```
- visit Tools > Yoast Test
- in the "Downgrade Yoast SEO" section, downgrade to 20.7 and save
- with Test Helper versions up to 1.18-RC5, you would get a fatal error
- with Test Helper versions 1.18-RC6, the operation would work as expected.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

Fixes #
