### PR TITLE
Improve I18N Issues (Based on 1.17)

### DIFF
--- a/src/indexing-reason-integration.php
+++ b/src/indexing-reason-integration.php
@@ -28,7 +28,8 @@ class Indexing_Reason_Integration implements Integration {
 		}
 
 		return \sprintf(
-			\esc_html__( 'Because some of your SEO data was reset by the %1$s, your SEO data needs to be reprocessed.', 'yoast-test-helper'  ),
+			/* translators: %1$s: Yoast Test Helper */
+			\esc_html__( 'Because some of your SEO data was reset by the %1$s, your SEO data needs to be reprocessed.', 'yoast-test-helper' ),
 			'Yoast Test Helper'
 		);
 	}

--- a/src/indexing-reason-integration.php
+++ b/src/indexing-reason-integration.php
@@ -28,7 +28,7 @@ class Indexing_Reason_Integration implements Integration {
 		}
 
 		return \sprintf(
-			\esc_html( 'Because some of your SEO data was reset by the %1$s, your SEO data needs to be reprocessed.' ),
+			\esc_html__( 'Because some of your SEO data was reset by the %1$s, your SEO data needs to be reprocessed.', 'yoast-test-helper'  ),
 			'Yoast Test Helper'
 		);
 	}

--- a/src/post-types.php
+++ b/src/post-types.php
@@ -150,7 +150,7 @@ class Post_Types implements Integration {
 			'labels'       => [
 				'name'          => \__( 'Books', 'yoast-test-helper' ),
 				'singular_name' => \__( 'Book', 'yoast-test-helper' ),
-				'add_new'       => \__( 'Add New', 'yoast-test-helper' ),
+				'add_new'       => \_x( 'Add New', 'Book', 'yoast-test-helper' ),
 				'add_new_item'  => \__( 'Add new book', 'yoast-test-helper' ),
 			],
 			'description'  => \__( 'Our books post type', 'yoast-test-helper' ),
@@ -175,7 +175,7 @@ class Post_Types implements Integration {
 			'labels'       => [
 				'name'          => \__( 'Movies', 'yoast-test-helper' ),
 				'singular_name' => \__( 'Movie', 'yoast-test-helper' ),
-				'add_new'       => \__( 'Add New', 'yoast-test-helper' ),
+				'add_new'       => \_x( 'Add New', 'Movie', 'yoast-test-helper' ),
 				'add_new_item'  => \__( 'Add new movie', 'yoast-test-helper' ),
 			],
 			'description'  => \__( 'Our movies post type', 'yoast-test-helper' ),


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Improves translation handling for post types registration and indexation reset. Props to @alexclassroom.

## Relevant technical choices:

*

## Milestone

* [ ] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Basically a regression test since strings may not be there (and definitely the second one isn't since it's new)
* Enable the custom post types (Books and Movies)
* check that you still see "Add new" in their submenus
* reset indexables and migrations
* visit the Yoast SEO General page and see that you get a notification saying `Because some of your SEO data was reset by the Yoast Test Helper, your SEO data needs to be reprocessed.`

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

Fixes #
