### PR TITLE
Added 'Requires Plugins: wordpress-seo' header

### DIFF
--- a/yoast-test-helper.php
+++ b/yoast-test-helper.php
@@ -18,6 +18,7 @@
  * License:     GPL v3
  * Requires at least: 6.3
  * Requires PHP: 7.2.5
+ * Requires Plugins: wordpress-seo
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
`Requires Plugins:` header helps to show a message to activate the Yoast SEO plugin first; in case if it was not enabled.

## Summary

This PR can be summarized in the following changelog entry:

* The `Requires Plugins:` header helps to show a message that the Yoast SEO free plugin is required to activate the Yoast Test Helper plugin on the Plugins page and will also show a message if someone tries to deactivate the Yoast SEO plugin without deactivating the Yoast Test Helper plugin.

## Relevant technical choices:

*

## Milestone

* [ ] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

Condition: 1
* Deactivate the Yoast SEO plugin, and try to install and activate the Yoast Test Helper
* It shows a message that the Yoast SEO plugin needs to be activated

Condition 2:
* Ensure that both Yoast SEO and Yoast Test Helper plugins are active
* Try to deactivate the Yoast SEO plugin, then you can notice a message that you need to deactivate the Yoast Test Helper plugin first to deactivate the Yoast SEO

Fixes #
