### PR TITLE
GH Actions: enable linting against PHP 8.4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,8 +33,7 @@ jobs:
     strategy:
       matrix:
         # Lint against the highest/lowest supported versions of each PHP major.
-        # And also do a run against "nightly" (the current dev version of PHP).
-        php_version: ['7.2', '7.4', '8.0', '8.2', '8.3']
+        php_version: ['7.2', '7.4', '8.0', '8.2', '8.4']
 
     name: "Lint: PHP ${{ matrix.php_version }}"
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Verified compatibility with PHP 8.4

## Relevant technical choices:

As the PHP 8.4 build passes and the PHP 8.4 release is expected later this month, the builds are not _allowed to fail_.


## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_