### PR TITLE
 Drop compatibility with PHP 7.2 and 7.3

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.2
+          php-version: 7.4
           coverage: none
 
       # This action also handles the caching of the Yarn dependencies.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         # Lint against the highest/lowest supported versions of each PHP major.
-        php_version: ['7.2', '7.4', '8.0', '8.2', '8.4']
+        php_version: ['7.4', '8.0', '8.2', '8.4']
 
     name: "Lint: PHP ${{ matrix.php_version }}"
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		"security": "https://yoast.com/security-program/"
 	},
 	"require": {
-		"php": "^7.2.5 || ^8.0",
+		"php": "^7.4 || ^8.0",
 		"ext-zip": "*"
 	},
 	"require-dev": {
@@ -36,7 +36,7 @@
 			"dealerdirect/phpcodesniffer-composer-installer": true
 		},
 		"platform": {
-			"php": "7.2.5"
+			"php": "7.4"
 		}
 	},
 	"scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ceb63fc410509381798527484ad26245",
+    "content-hash": "64747a0bfcc95cc3744e5b94f5a5e7c4",
     "packages": [],
     "packages-dev": [
         {
@@ -507,22 +507,22 @@
         },
         {
             "name": "phpcsstandards/phpcsextra",
-            "version": "1.2.1",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
-                "reference": "11d387c6642b6e4acaf0bd9bf5203b8cca1ec489"
+                "reference": "46d08eb86eec622b96c466adec3063adfed280dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/11d387c6642b6e4acaf0bd9bf5203b8cca1ec489",
-                "reference": "11d387c6642b6e4acaf0bd9bf5203b8cca1ec489",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/46d08eb86eec622b96c466adec3063adfed280dd",
+                "reference": "46d08eb86eec622b96c466adec3063adfed280dd",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4",
                 "phpcsstandards/phpcsutils": "^1.0.9",
-                "squizlabs/php_codesniffer": "^3.8.0"
+                "squizlabs/php_codesniffer": "^3.12.1"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0",
@@ -579,9 +579,13 @@
                 {
                     "url": "https://opencollective.com/php_codesniffer",
                     "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
                 }
             ],
-            "time": "2023-12-08T16:49:07+00:00"
+            "time": "2025-04-20T23:35:32+00:00"
         },
         {
             "name": "phpcsstandards/phpcsutils",
@@ -673,30 +677,30 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.33.0",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "82a311fd3690fb2bf7b64d5c98f912b3dd746140"
+                "reference": "9b30d6fd026b2c132b3985ce6b23bec09ab3aa68"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/82a311fd3690fb2bf7b64d5c98f912b3dd746140",
-                "reference": "82a311fd3690fb2bf7b64d5c98f912b3dd746140",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/9b30d6fd026b2c132b3985ce6b23bec09ab3aa68",
+                "reference": "9b30d6fd026b2c132b3985ce6b23bec09ab3aa68",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2 || ^8.0"
+                "php": "^7.4 || ^8.0"
             },
             "require-dev": {
                 "doctrine/annotations": "^2.0",
-                "nikic/php-parser": "^4.15",
+                "nikic/php-parser": "^5.3.0",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^1.5",
-                "phpstan/phpstan-phpunit": "^1.1",
-                "phpstan/phpstan-strict-rules": "^1.0",
-                "phpunit/phpunit": "^9.5",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
                 "symfony/process": "^5.2"
             },
             "type": "library",
@@ -714,9 +718,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.33.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.1.0"
             },
-            "time": "2024-10-13T11:25:22+00:00"
+            "time": "2025-02-19T13:28:12+00:00"
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",
@@ -777,32 +781,32 @@
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "8.15.0",
+            "version": "8.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "7d1d957421618a3803b593ec31ace470177d7817"
+                "reference": "ace04a4e2e20c9bc26ad14d6c4c737cde6056ec0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/7d1d957421618a3803b593ec31ace470177d7817",
-                "reference": "7d1d957421618a3803b593ec31ace470177d7817",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/ace04a4e2e20c9bc26ad14d6c4c737cde6056ec0",
+                "reference": "ace04a4e2e20c9bc26ad14d6c4c737cde6056ec0",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0",
-                "php": "^7.2 || ^8.0",
-                "phpstan/phpdoc-parser": "^1.23.1",
-                "squizlabs/php_codesniffer": "^3.9.0"
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpdoc-parser": "^2.1.0",
+                "squizlabs/php_codesniffer": "^3.12.1"
             },
             "require-dev": {
-                "phing/phing": "2.17.4",
-                "php-parallel-lint/php-parallel-lint": "1.3.2",
-                "phpstan/phpstan": "1.10.60",
-                "phpstan/phpstan-deprecation-rules": "1.1.4",
-                "phpstan/phpstan-phpunit": "1.3.16",
-                "phpstan/phpstan-strict-rules": "1.5.2",
-                "phpunit/phpunit": "8.5.21|9.6.8|10.5.11"
+                "phing/phing": "3.0.1",
+                "php-parallel-lint/php-parallel-lint": "1.4.0",
+                "phpstan/phpstan": "2.1.11",
+                "phpstan/phpstan-deprecation-rules": "2.0.1",
+                "phpstan/phpstan-phpunit": "2.0.6",
+                "phpstan/phpstan-strict-rules": "2.0.4",
+                "phpunit/phpunit": "9.6.8|10.5.45|11.4.4|11.5.17|12.1.2"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -826,7 +830,7 @@
             ],
             "support": {
                 "issues": "https://github.com/slevomat/coding-standard/issues",
-                "source": "https://github.com/slevomat/coding-standard/tree/8.15.0"
+                "source": "https://github.com/slevomat/coding-standard/tree/8.17.0"
             },
             "funding": [
                 {
@@ -838,20 +842,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-03-09T15:20:58+00:00"
+            "time": "2025-04-10T06:06:16+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.12.0",
+            "version": "3.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "2d1b63db139c3c6ea0c927698e5160f8b3b8d630"
+                "reference": "6d4cf6032d4b718f168c90a96e36c7d0eaacb2aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/2d1b63db139c3c6ea0c927698e5160f8b3b8d630",
-                "reference": "2d1b63db139c3c6ea0c927698e5160f8b3b8d630",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/6d4cf6032d4b718f168c90a96e36c7d0eaacb2aa",
+                "reference": "6d4cf6032d4b718f168c90a96e36c7d0eaacb2aa",
                 "shasum": ""
             },
             "require": {
@@ -922,7 +926,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-03-18T05:04:51+00:00"
+            "time": "2025-04-13T04:10:18+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -1055,16 +1059,16 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.2.5 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "ext-zip": "*"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
-        "php": "7.2.5"
+        "php": "7.4"
     },
     "plugin-api-version": "2.6.0"
 }

--- a/languages/yoast-test-helper.pot
+++ b/languages/yoast-test-helper.pot
@@ -1,14 +1,14 @@
-# Copyright (C) 2024 Team Yoast
+# Copyright (C) 2025 Team Yoast
 # This file is distributed under the GPL v3.
 msgid ""
 msgstr ""
 "Project-Id-Version: Yoast Test Helper 1.18\n"
 "Report-Msgid-Bugs-To: https://github.com/yoast/yoast-test-helper/issues\n"
-"POT-Creation-Date: 2024-02-01 12:10:29+00:00\n"
+"POT-Creation-Date: 2025-04-23 09:29:11+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2024-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2025-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Yoast Translate Team <translations@yoast.com>\n"
 "Language-Team: Yoast Translate <translations@yoast.com>\n"
 "Language: en\n"
@@ -24,11 +24,11 @@ msgstr ""
 "X-Textdomain-Support: yes\n"
 "X-Generator: grunt-wp-i18n 1.0.3\n"
 
-#: src/admin-bar-panel.php:25
+#: src/admin-bar-panel.php:27
 msgid "Debug Information"
 msgstr ""
 
-#: src/admin-bar-panel.php:33
+#: src/admin-bar-panel.php:35
 msgid "Option"
 msgstr ""
 
@@ -100,26 +100,26 @@ msgstr ""
 msgid "A migration is already in progress. Please try again later."
 msgstr ""
 
-#: src/downgrader.php:159
+#: src/downgrader.php:160
 #. translators: %1$s is the class name of the migration that failed, %2$s is
 #. the message given by the failure.
 msgid "Migration %1$s failed with the message: %2$s"
 msgstr ""
 
-#: src/downgrader.php:172
+#: src/downgrader.php:174
 msgid "Could not unpack the requested version."
 msgstr ""
 
-#: src/downgrader.php:188
+#: src/downgrader.php:190
 msgid "Could not install the requested version."
 msgstr ""
 
-#: src/feature-toggler.php:65
+#: src/feature-toggler.php:64
 #. translators: %s expands to the label.
 msgid "Enable %s"
 msgstr ""
 
-#: src/feature-toggler.php:70
+#: src/feature-toggler.php:69
 msgid "Feature toggler"
 msgstr ""
 
@@ -127,27 +127,27 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: src/indexing-reason-integration.php:32
+#: src/indexing-reason-integration.php:34
 #. translators: %1$s: Yoast Test Helper
 msgid ""
 "Because some of your SEO data was reset by the %1$s, your SEO data needs to "
 "be reprocessed."
 msgstr ""
 
-#: src/inline-script.php:57
+#: src/inline-script.php:59
 msgid "Add the inline script specified below after the script selected here."
 msgstr ""
 
-#: src/inline-script.php:61
+#: src/inline-script.php:63
 msgid "After script"
 msgstr ""
 
-#: src/inline-script.php:69
+#: src/inline-script.php:71
 #. translators: %1$s expands to the `script` tag.
 msgid "Script (do not include %1$s tags):"
 msgstr ""
 
-#: src/inline-script.php:73
+#: src/inline-script.php:75
 msgid "Inline script"
 msgstr ""
 
@@ -179,23 +179,23 @@ msgstr ""
 msgid "Plugin options & database versions"
 msgstr ""
 
-#: src/plugin-version-control.php:111
+#: src/plugin-version-control.php:113
 #. translators: %1$s expands to the plugin name, %2$s to the version.
 msgid "%1$s version was set to %2$s."
 msgstr ""
 
-#: src/plugin-version-control.php:126
+#: src/plugin-version-control.php:128
 #. translators: %1$s expands to the plugin name.
 msgid "%1$s options were saved."
 msgstr ""
 
-#: src/plugin-version-control.php:215
+#: src/plugin-version-control.php:217
 #. translators: %1$s expands to date, %2$s to plugin name, %3$s and %4$s to
 #. HTML strong tags.
 msgid "Options from %1$s for %2$s have %3$snot%4$s been restored."
 msgstr ""
 
-#: src/plugin-version-control.php:228
+#: src/plugin-version-control.php:230
 #. translators: %1$s expands to date, %2$s to plugin name.
 msgid "Options from %1$s for %2$s have been restored."
 msgstr ""
@@ -216,63 +216,63 @@ msgstr ""
 msgid "Post types & Taxonomies"
 msgstr ""
 
-#: src/post-types.php:149 src/post-types.php:151
+#: src/post-types.php:153 src/post-types.php:155
 msgid "Books"
 msgstr ""
 
-#: src/post-types.php:152
+#: src/post-types.php:156
 msgid "Book"
 msgstr ""
 
-#: src/post-types.php:154
+#: src/post-types.php:158
 msgid "Add new book"
 msgstr ""
 
-#: src/post-types.php:156
+#: src/post-types.php:160
 msgid "Our books post type"
 msgstr ""
 
-#: src/post-types.php:174 src/post-types.php:176
+#: src/post-types.php:178 src/post-types.php:180
 msgid "Movies"
 msgstr ""
 
-#: src/post-types.php:177
+#: src/post-types.php:181
 msgid "Movie"
 msgstr ""
 
-#: src/post-types.php:179
+#: src/post-types.php:183
 msgid "Add new movie"
 msgstr ""
 
-#: src/post-types.php:181
+#: src/post-types.php:185
 msgid "Our movies post type"
 msgstr ""
 
-#: src/schema.php:99
+#: src/schema.php:105
 msgid "Don't influence"
 msgstr ""
 
-#: src/schema.php:100
+#: src/schema.php:106
 msgid "Always include"
 msgstr ""
 
-#: src/schema.php:101
+#: src/schema.php:107
 msgid "Never include"
 msgstr ""
 
-#: src/schema.php:106
+#: src/schema.php:112
 msgid "Influence the Breadcrumb Graph piece: "
 msgstr ""
 
-#: src/schema.php:113
+#: src/schema.php:119
 msgid "Influence the WebPage Graph piece: "
 msgstr ""
 
-#: src/schema.php:120
+#: src/schema.php:126
 msgid "Replace .test domain name with example.com in Schema output."
 msgstr ""
 
-#: src/schema.php:128
+#: src/schema.php:134
 #. translators: %1$ss is replaced by `<code>/schema/</code>`, %2$s is replaced
 #. by `<code>?schema</code>`.
 msgid ""
@@ -280,47 +280,47 @@ msgid ""
 "to get the Schema for that URL, pretty printed."
 msgstr ""
 
-#: src/schema.php:135
+#: src/schema.php:141
 msgid "Schema"
 msgstr ""
 
-#: src/taxonomies.php:57 src/taxonomies.php:59
+#: src/taxonomies.php:61 src/taxonomies.php:63
 msgid "Categories"
 msgstr ""
 
-#: src/taxonomies.php:60
+#: src/taxonomies.php:64
 msgid "Category"
 msgstr ""
 
-#: src/taxonomies.php:80 src/taxonomies.php:82
+#: src/taxonomies.php:84 src/taxonomies.php:86
 msgid "Genres"
 msgstr ""
 
-#: src/taxonomies.php:83 src/taxonomies.php:90
+#: src/taxonomies.php:87 src/taxonomies.php:94
 msgid "Genre"
 msgstr ""
 
-#: src/taxonomies.php:84
+#: src/taxonomies.php:88
 msgid "Search Genres"
 msgstr ""
 
-#: src/taxonomies.php:85
+#: src/taxonomies.php:89
 msgid "All Genres"
 msgstr ""
 
-#: src/taxonomies.php:86
+#: src/taxonomies.php:90
 msgid "Edit Genre"
 msgstr ""
 
-#: src/taxonomies.php:87
+#: src/taxonomies.php:91
 msgid "Update Genre"
 msgstr ""
 
-#: src/taxonomies.php:88
+#: src/taxonomies.php:92
 msgid "Add New Genre"
 msgstr ""
 
-#: src/taxonomies.php:89
+#: src/taxonomies.php:93
 msgid "New Genre Name"
 msgstr ""
 
@@ -408,15 +408,15 @@ msgstr ""
 msgid "Cornerstone flags"
 msgstr ""
 
-#: src/xml-sitemaps.php:69
+#: src/xml-sitemaps.php:71
 msgid "Disable the XML sitemaps cache."
 msgstr ""
 
-#: src/xml-sitemaps.php:72
+#: src/xml-sitemaps.php:74
 msgid "Maximum entries per XML sitemap:"
 msgstr ""
 
-#: src/xml-sitemaps.php:75
+#: src/xml-sitemaps.php:77
 msgid "XML Sitemaps"
 msgstr ""
 
@@ -436,12 +436,12 @@ msgstr ""
 msgid "https://yoa.st/team-yoast-test-helper"
 msgstr ""
 
-#: src/post-types.php:153
+#: src/post-types.php:157
 msgctxt "Book"
 msgid "Add New"
 msgstr ""
 
-#: src/post-types.php:178
+#: src/post-types.php:182
 msgctxt "Movie"
 msgid "Add New"
 msgstr ""

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: Yoast, Yoast SEO, development
 Requires at least: 6.6
 Tested up to: 6.8
 Stable tag: 1.18
-Requires PHP: 7.2.5
+Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/yoast-test-helper.php
+++ b/yoast-test-helper.php
@@ -17,7 +17,7 @@
  * Domain Path: /languages/
  * License:     GPL v3
  * Requires at least: 6.6
- * Requires PHP: 7.2.5
+ * Requires PHP: 7.4
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Drops compatibility with PHP 7.2 and 7.3.

## Relevant technical choices:

* N/A

## Milestone

* [ ] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Follow the same test instructions in [this](https://github.com/Yoast/wordpress-seo/pull/22077) PR.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.


Fixes [#240](https://github.com/Yoast/yoast-test-helper/issues/240)
