### PR TITLE
Add ability to toggle Site Kit dashboard feature.

### DIFF
--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -84,6 +84,7 @@ class Yoast_SEO implements WordPress_Plugin {
 			'reset_premium_workouts'             => \esc_html__( 'Premium workouts progress', 'yoast-test-helper' ),
 			'reset_options'                      => \esc_html__( 'Options', 'yoast-test-helper' ),
 			'reset_cornerstone_flags'            => \esc_html__( 'Cornerstone flags', 'yoast-test-helper' ),
+			'toggle_site_kit_feature'            => \esc_html__( 'Toggle Site Kit feature flag', 'yoast-test-helper' ),
 		];
 	}
 
@@ -132,6 +133,9 @@ class Yoast_SEO implements WordPress_Plugin {
 			case 'reset_cornerstone_flags':
 				$this->reset_cornerstone_flags();
 				return true;
+			case 'toggle_site_kit_feature':
+				$this->toggle_site_kit_feature();
+				return true;
 		}
 
 		return false;
@@ -160,6 +164,15 @@ class Yoast_SEO implements WordPress_Plugin {
 		\delete_transient( 'wpseo_unindexed_term_link_count' );
 
 		$this->reset_indexing_notification( 'indexables-reset-by-test-helper' );
+	}
+
+	/**
+	 * Toggles the Site Kit feature flag.
+	 *
+	 * @return void
+	 */
+	private function toggle_site_kit_feature() {
+		WPSEO_Options::set( 'google_site_kit_feature_enabled', ! WPSEO_Options::get( 'google_site_kit_feature_enabled' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds the option to toggle the Site Kit Dashboard feature feature-flag.

## Relevant technical choices:

*

## Milestone

* [ ] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* This is needed for: https://github.com/Yoast/wordpress-seo/pull/22217

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

Fixes #
