### PR TITLE
Remove maxlength from upgrade routine inputs

### DIFF
--- a/src/plugin-version-control.php
+++ b/src/plugin-version-control.php
@@ -143,7 +143,7 @@ class Plugin_Version_Control implements Integration {
 	 */
 	protected function get_plugin_option( WordPress_Plugin $plugin ) {
 		return \sprintf(
-			'<tr><td>%s:</td><td><input type="text" name="%s" value="%s" maxlength="9" size="10"></td><td>(%s)</td><td>%s</td></tr>',
+			'<tr><td>%s:</td><td><input type="text" name="%s" value="%s" size="10"></td><td>(%s)</td><td>%s</td></tr>',
 			\esc_html( $plugin->get_name() ),
 			\esc_attr( $plugin->get_identifier() ),
 			\esc_attr( $this->plugin_version->get_version( $plugin ) ),


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Removes `maxlength` from the input fields of the upgrade routines.

## Relevant technical choices:

*

## Milestone

* [ ] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to Tools->Yoast Test
* Perform an upgrade with the usual way of adding a previous version in the DB version field, but this time give a version that has over 10 digits. For example, if you are on 26.1, type `26.0.0.0.0.0.0.0.0.0.1`
* Confirm that you are able to type that whole version there
* Perform the upgrade routine and just make sure you dont get any errors after the form submission.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

Fixes #
