### PR TITLE
GH Actions: improve "don't run on forks" condition

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # Don't run the cronjob in this workflow on forks.
-    if: github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository_owner == 'Yoast')
+    if: github.event_name != 'schedule' || github.event.repository.fork == false
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* CI improvements

## Relevant technical choices:

* Remove the condition containing a hard-coded repository/organisation name in favour of a more generic condition which should safeguard that the cron job doesn't run on forks just the same.


## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_