### PR TITLE
GH Actions: persist credentials for deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -154,7 +154,7 @@ jobs:
           # Personal Access Token for (push) access to the dist version of the repo.
           token: ${{ secrets.YOASTBOT_CI_PAT_DIST }}
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true
 
       - name: "Create branch/Switch to branch"
         if: ${{ steps.set_vars.outputs.BRANCH != env.DIST_DEFAULT_BRANCH }}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Improve CI security

## Relevant technical choices:

Follow up on #261.

Okay, so the manual test deploy of the `develop` branch via the `workflow_dispatch` trigger did not succeed.

In that case, let's make it explicit that this particular job needs the credentials being set by `actions/checkout` by setting `persist-credentials` to `true`.

Will test again after merging this.

## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* This really does need testing to verify this doesn't break the deploy. Will try via the manual "workflow dispatch" trigger after merging this and will revert if the deploy would not work.