### PR TITLE
Admin_Bar_Panel: remove redundant `echo`

### DIFF
--- a/src/admin-bar-panel.php
+++ b/src/admin-bar-panel.php
@@ -34,8 +34,8 @@ class Admin_Bar_Panel extends Debug_Bar_Panel {
 		foreach ( WPSEO_Options::get_option_names() as $option ) {
 			echo '<h3 id="', \esc_attr( $option ), '">', \esc_html__( 'Option', 'yoast-test-helper' ), ': <span class="wpseo-debug">', \esc_html( $option ), '</span></h3>';
 			echo '<pre>';
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export,WordPress.Security.EscapeOutput.OutputNotEscaped
-			echo \var_export( \get_option( $option ) );
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+			\var_export( \get_option( $option ) );
 			echo '</pre>';
 		}
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Clean up code

## Relevant technical choices:

`var_export()` (without the `$return` param set to `true`) will already echo out the results, so the `echo` is redundant.

Refs:
* https://www.php.net/var_export
* https://3v4l.org/kUGCE


## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* See the above linked 3v4l
