### PR TITLE
GH Actions: enable linting against PHP 8.5

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         # Lint against the highest/lowest supported versions of each PHP major.
-        php_version: ['7.4', '8.0', '8.2', '8.4']
+        php_version: ['7.4', '8.0', '8.2', '8.5']
 
     name: "Lint: PHP ${{ matrix.php_version }}"
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* The plugin has no known incompatibilities with PHP up to 8.5.

## Relevant technical choices:

* As the PHP 8.5 builds pass and the PHP 8.5 has been released last month, the builds are not _allowed to fail_.


## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_