### PR TITLE
Set the minimum supported WordPress version to 6.8

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Yoast Test Helper ===
 Contributors: yoast, joostdevalk, omarreiss, jipmoors, herregroen
 Tags: Yoast, Yoast SEO, development
-Requires at least: 6.7
+Requires at least: 6.8
 Tested up to: 6.9
 Stable tag: 1.18
 Requires PHP: 7.4

--- a/yoast-test-helper.php
+++ b/yoast-test-helper.php
@@ -16,7 +16,7 @@
  * Text Domain: yoast-test-helper
  * Domain Path: /languages/
  * License:     GPL v3
- * Requires at least: 6.7
+ * Requires at least: 6.8
  * Requires PHP: 7.4
  *
  * This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Sets the minimum supported WordPress version to 6.8.

## Relevant technical choices:

* [Previous iteration](https://github.com/Yoast/yoast-test-helper/pull/244)

## Milestone

* [ ] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

Fixes #
