### PR TITLE
Modernize: use trailing comma in multi-line function call

### DIFF
--- a/config/composer/actions.php
+++ b/config/composer/actions.php
@@ -120,7 +120,7 @@ class Actions {
 		$command    = \sprintf(
 			'composer check-cs-warnings -- %s %s',
 			\implode( ' ', \array_map( 'escapeshellarg', $php_files ) ),
-			$extra_args
+			$extra_args,
 		);
 		\system( $command, $exit_code );
 
@@ -196,7 +196,7 @@ class Actions {
 			$files,
 			static function ( $file ) use ( $extension ) {
 				return \substr( $file, ( 0 - \strlen( $extension ) ) ) === $extension;
-			}
+			},
 		);
 	}
 }

--- a/src/admin-debug-info.php
+++ b/src/admin-debug-info.php
@@ -35,7 +35,7 @@ class Admin_Debug_Info implements Integration {
 
 		\add_action(
 			'admin_post_yoast_seo_debug_settings',
-			[ $this, 'handle_submit' ]
+			[ $this, 'handle_submit' ],
 		);
 	}
 
@@ -64,7 +64,7 @@ class Admin_Debug_Info implements Integration {
 			'show_options_debug',
 			/* translators: %1$s and %2$s expand to link to debug bar. */
 			\sprintf( \esc_html__( 'Add Yoast SEO panel to %1$sDebug Bar%2$s.', 'yoast-test-helper' ), '<a href="https://wordpress.org/plugins/debug-bar/">', '</a>' ),
-			$this->option->get( 'show_options_debug' )
+			$this->option->get( 'show_options_debug' ),
 		);
 
 		return Form_Presenter::get_html( \__( 'Debug Bar integration', 'yoast-test-helper' ), 'yoast_seo_debug_settings', $fields );

--- a/src/admin-page.php
+++ b/src/admin-page.php
@@ -45,7 +45,7 @@ class Admin_Page implements Integration {
 			'yoast-test-admin-style',
 			\plugin_dir_url( \YOAST_TEST_HELPER_FILE ) . 'assets/css/admin.css',
 			[],
-			\YOAST_TEST_HELPER_VERSION
+			\YOAST_TEST_HELPER_VERSION,
 		);
 		\wp_enqueue_script( 'masonry' );
 	}
@@ -61,7 +61,7 @@ class Admin_Page implements Integration {
 			\esc_html__( 'Yoast Test', 'yoast-test-helper' ),
 			'manage_options',
 			\sanitize_key( $this->get_admin_page() ),
-			[ $this, 'show_admin_page' ]
+			[ $this, 'show_admin_page' ],
 		);
 		\add_action( 'admin_print_styles-' . $menu_item, [ $this, 'add_assets' ] );
 	}

--- a/src/development-mode.php
+++ b/src/development-mode.php
@@ -48,13 +48,13 @@ class Development_Mode implements Integration {
 		$fields = Form_Presenter::create_checkbox(
 			'enable_development_mode',
 			\esc_html__( 'Enable development mode.', 'yoast-test-helper' ),
-			$this->option->get( 'enable_development_mode' )
+			$this->option->get( 'enable_development_mode' ),
 		);
 
 		$fields .= Form_Presenter::create_checkbox(
 			'use_ai_staging_api',
 			\esc_html__( 'Switch to AI staging API', 'yoast-test-helper' ),
-			$this->option->get( 'use_ai_staging_api' )
+			$this->option->get( 'use_ai_staging_api' ),
 		);
 
 		return Form_Presenter::get_html( \__( 'Development settings', 'yoast-test-helper' ), 'yoast_seo_test_development_mode', $fields );

--- a/src/domain-dropdown.php
+++ b/src/domain-dropdown.php
@@ -58,7 +58,7 @@ class Domain_Dropdown implements Integration {
 			'myyoast_test_domain',
 			\esc_html__( 'Set the myYoast testing domain to: ', 'yoast-test-helper' ),
 			$select_options,
-			$this->option->get( 'myyoast_test_domain' )
+			$this->option->get( 'myyoast_test_domain' ),
 		);
 
 		return Form_Presenter::get_html( \__( 'Domain Dropdown', 'yoast-test-helper' ), 'yoast_seo_domain_dropdown', $output );

--- a/src/downgrader.php
+++ b/src/downgrader.php
@@ -39,7 +39,7 @@ class Downgrader implements Integration {
 		$title = \sprintf(
 			/* translators: %1$s is Yoast SEO. */
 			\__( 'Downgrade %1$s', 'yoast-test-helper' ),
-			'Yoast SEO'
+			'Yoast SEO',
 		);
 
 		return Form_Presenter::get_html( $title, 'yoast_rollback_control', $output );
@@ -69,15 +69,15 @@ class Downgrader implements Integration {
 						/* translators: %1$s is Yoast SEO, %2$s is the version number it was downgraded to. */
 						\__( '%1$s has been succesfully downgraded to version %2$s.', 'yoast-test-helper' ),
 						'Yoast SEO',
-						$target_version
+						$target_version,
 					),
-					'success'
-				)
+					'success',
+				),
 			);
 		} catch ( Exception $e ) {
 			\do_action(
 				'Yoast\WP\Test_Helper\notification',
-				new Notification( $e->getMessage(), 'error' )
+				new Notification( $e->getMessage(), 'error' ),
 			);
 		}
 
@@ -159,11 +159,11 @@ class Downgrader implements Integration {
 							/* translators: %1$s is the class name of the migration that failed, %2$s is the message given by the failure. */
 							\__( 'Migration %1$s failed with the message: %2$s', 'yoast-test-helper' ),
 							$class,
-							$e->getMessage()
-						)
+							$e->getMessage(),
+						),
 					),
 					0,
-					$e // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- This is an exception object.
+					$e, // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- This is an exception object.
 				);
 			}
 		}
@@ -184,7 +184,7 @@ class Downgrader implements Integration {
 					'type'   => 'plugin',
 					'action' => 'install',
 				],
-			]
+			],
 		);
 		if ( \is_wp_error( $result ) ) {
 			throw new Exception( \esc_html__( 'Could not install the requested version.', 'yoast-test-helper' ) );

--- a/src/feature-toggler.php
+++ b/src/feature-toggler.php
@@ -40,7 +40,7 @@ class Feature_Toggler implements Integration {
 
 		\add_action(
 			'admin_post_yoast_seo_feature_toggler',
-			[ $this, 'handle_submit' ]
+			[ $this, 'handle_submit' ],
 		);
 	}
 
@@ -62,7 +62,7 @@ class Feature_Toggler implements Integration {
 				$key,
 				/* translators: %s expands to the label. */
 				\sprintf( \esc_html__( 'Enable %s', 'yoast-test-helper' ), $label ),
-				$this->option->get( $key )
+				$this->option->get( $key ),
 			);
 		}
 

--- a/src/indexing-reason-integration.php
+++ b/src/indexing-reason-integration.php
@@ -32,7 +32,7 @@ class Indexing_Reason_Integration implements Integration {
 		return \sprintf(
 			/* translators: %1$s: Yoast Test Helper */
 			\esc_html__( 'Because some of your SEO data was reset by the %1$s, your SEO data needs to be reprocessed.', 'yoast-test-helper' ),
-			'Yoast Test Helper'
+			'Yoast Test Helper',
 		);
 	}
 }

--- a/src/inline-script.php
+++ b/src/inline-script.php
@@ -44,7 +44,7 @@ class Inline_Script implements Integration {
 		}
 		\wp_add_inline_script(
 			$this->option->get( 'inline_script_handle' ),
-			$this->option->get( 'inline_script' )
+			$this->option->get( 'inline_script' ),
 		);
 	}
 
@@ -57,7 +57,7 @@ class Inline_Script implements Integration {
 		$output = Form_Presenter::create_checkbox(
 			'add_inline_script',
 			\esc_html__( 'Add the inline script specified below after the script selected here.', 'yoast-test-helper' ),
-			$this->option->get( 'add_inline_script' )
+			$this->option->get( 'add_inline_script' ),
 		) . '<br/>';
 
 		$output .= '<label for="inline_script_handle">' . \__( 'After script', 'yoast-test-helper' ) . ': </label>';

--- a/src/plugin-toggler.php
+++ b/src/plugin-toggler.php
@@ -49,7 +49,7 @@ class Plugin_Toggler implements Integration {
 
 		\add_action(
 			'admin_post_yoast_seo_plugin_toggler',
-			[ $this, 'handle_submit' ]
+			[ $this, 'handle_submit' ],
 		);
 	}
 
@@ -119,7 +119,7 @@ class Plugin_Toggler implements Integration {
 					'id'     => $menu_id,
 					'title'  => $menu_title,
 					'href'   => '#',
-				]
+				],
 			);
 
 			// Add a node for each plugin.
@@ -139,10 +139,10 @@ class Plugin_Toggler implements Integration {
 								'Yoast_Plugin_Toggler.toggle_plugin( "%1$s", "%2$s", "%3$s" )',
 								$group,
 								$plugin,
-								$nonce
+								$nonce,
 							),
 						],
-					]
+					],
 				);
 			}
 		}
@@ -160,7 +160,7 @@ class Plugin_Toggler implements Integration {
 			\plugin_dir_url( \YOAST_TEST_HELPER_FILE ) . 'assets/js/yoast-toggle.js',
 			[],
 			\YOAST_TEST_HELPER_VERSION,
-			true
+			true,
 		);
 	}
 
@@ -211,7 +211,7 @@ class Plugin_Toggler implements Integration {
 		$fields = Form_Presenter::create_checkbox(
 			'plugin_toggler',
 			\esc_html__( 'Show plugin toggler.', 'yoast-test-helper' ),
-			$this->option->get( 'plugin_toggler' )
+			$this->option->get( 'plugin_toggler' ),
 		);
 
 		return Form_Presenter::get_html( \__( 'Plugin toggler', 'yoast-test-helper' ), 'yoast_seo_plugin_toggler', $fields );

--- a/src/plugin-version-control.php
+++ b/src/plugin-version-control.php
@@ -112,10 +112,10 @@ class Plugin_Version_Control implements Integration {
 						/* translators: %1$s expands to the plugin name, %2$s to the version. */
 						\__( '%1$s version was set to %2$s.', 'yoast-test-helper' ),
 						$plugin->get_name(),
-						$version
+						$version,
 					),
-					'success'
-				)
+					'success',
+				),
 			);
 		}
 
@@ -126,10 +126,10 @@ class Plugin_Version_Control implements Integration {
 					\sprintf(
 						/* translators: %1$s expands to the plugin name. */
 						\__( '%1$s options were saved.', 'yoast-test-helper' ),
-						$plugin->get_name()
+						$plugin->get_name(),
 					),
-					'success'
-				)
+					'success',
+				),
 			);
 		}
 	}
@@ -148,7 +148,7 @@ class Plugin_Version_Control implements Integration {
 			\esc_attr( $plugin->get_identifier() ),
 			\esc_attr( $this->plugin_version->get_version( $plugin ) ),
 			\esc_html( $plugin->get_version_constant() ),
-			$this->get_option_history_select( $plugin )
+			$this->get_option_history_select( $plugin ),
 		);
 	}
 
@@ -186,13 +186,13 @@ class Plugin_Version_Control implements Integration {
 							'<option value="%s">(%s) %s</option>',
 							\esc_attr( $timestamp ),
 							\esc_html( $version ),
-							\esc_html( \gmdate( 'Y-m-d H:i:s', $timestamp ) )
+							\esc_html( \gmdate( 'Y-m-d H:i:s', $timestamp ) ),
 						);
 					},
 					\array_keys( $history ),
-					$history
-				)
-			)
+					$history,
+				),
+			),
 		);
 	}
 
@@ -218,9 +218,9 @@ class Plugin_Version_Control implements Integration {
 						\gmdate( 'Y-m-d H:i:s', $timestamp ),
 						$plugin->get_name(),
 						'<strong>',
-						'</strong>'
+						'</strong>',
 					),
-					'error'
+					'error',
 				);
 
 				if ( $this->plugin_options->restore_options( $plugin, $timestamp ) ) {
@@ -229,9 +229,9 @@ class Plugin_Version_Control implements Integration {
 							/* translators: %1$s expands to date, %2$s to plugin name. */
 							\esc_html__( 'Options from %1$s for %2$s have been restored.', 'yoast-test-helper' ),
 							\gmdate( 'Y-m-d H:i:s', $timestamp ),
-							$plugin->get_name()
+							$plugin->get_name(),
 						),
-						'success'
+						'success',
 					);
 				}
 

--- a/src/plugin.php
+++ b/src/plugin.php
@@ -41,7 +41,7 @@ class Plugin implements Integration {
 			static function ( Integration $integration ) {
 				$integration->add_hooks();
 			},
-			$this->integrations
+			$this->integrations,
 		);
 	}
 
@@ -71,7 +71,7 @@ class Plugin implements Integration {
 		$plugin_version_control = new Plugin_Version_Control(
 			$plugins,
 			new WordPress_Plugin_Version(),
-			new WordPress_Plugin_Options()
+			new WordPress_Plugin_Options(),
 		);
 
 		$option = new Option();

--- a/src/post-types.php
+++ b/src/post-types.php
@@ -76,19 +76,19 @@ class Post_Types implements Integration {
 		$fields = Form_Presenter::create_checkbox(
 			'enable_post_types',
 			\esc_html__( 'Enable post types & taxonomies.', 'yoast-test-helper' ),
-			$this->option->get( 'enable_post_types' )
+			$this->option->get( 'enable_post_types' ),
 		);
 
 		$fields .= Form_Presenter::create_checkbox(
 			'enable_gutenberg_books',
 			\esc_html__( 'Enable block editor for Books.', 'yoast-test-helper' ),
-			$this->option->get( 'enable_gutenberg_books' )
+			$this->option->get( 'enable_gutenberg_books' ),
 		);
 
 		$fields .= Form_Presenter::create_checkbox(
 			'enable_gutenberg_videos',
 			\esc_html__( 'Enable block editor for Videos.', 'yoast-test-helper' ),
-			$this->option->get( 'enable_gutenberg_videos' )
+			$this->option->get( 'enable_gutenberg_videos' ),
 		);
 
 		return Form_Presenter::get_html( \__( 'Post types & Taxonomies', 'yoast-test-helper' ), 'yoast_seo_test_post_types', $fields );
@@ -116,8 +116,8 @@ class Post_Types implements Integration {
 
 		\wp_safe_redirect(
 			\self_admin_url(
-				'tools.php?page=' . \apply_filters( 'Yoast\WP\Test_Helper\admin_page', '' )
-			)
+				'tools.php?page=' . \apply_filters( 'Yoast\WP\Test_Helper\admin_page', '' ),
+			),
 		);
 	}
 

--- a/src/schema.php
+++ b/src/schema.php
@@ -111,20 +111,20 @@ class Schema implements Integration {
 			'is_needed_breadcrumb',
 			\esc_html__( 'Influence the Breadcrumb Graph piece: ', 'yoast-test-helper' ),
 			$select_options,
-			$this->option->get( 'is_needed_breadcrumb' )
+			$this->option->get( 'is_needed_breadcrumb' ),
 		);
 
 		$output .= Form_Presenter::create_select(
 			'is_needed_webpage',
 			\esc_html__( 'Influence the WebPage Graph piece: ', 'yoast-test-helper' ),
 			$select_options,
-			$this->option->get( 'is_needed_webpage' )
+			$this->option->get( 'is_needed_webpage' ),
 		);
 
 		$output .= Form_Presenter::create_checkbox(
 			'replace_schema_domain',
 			\esc_html__( 'Replace .test domain name with example.com in Schema output.', 'yoast-test-helper' ),
-			$this->option->get( 'replace_schema_domain' )
+			$this->option->get( 'replace_schema_domain' ),
 		);
 
 		$output .= Form_Presenter::create_checkbox(
@@ -133,9 +133,9 @@ class Schema implements Integration {
 				/* translators: %1$ss is replaced by `<code>/schema/</code>`, %2$s is replaced by `<code>?schema</code>`. */
 				\esc_html__( 'Enable the Schema endpoint for every URL: suffix the URL with %1$s or %2$s to get the Schema for that URL, pretty printed.', 'yoast-test-helper' ),
 				'<code>/schema/</code>',
-				'<code>?schema</code>'
+				'<code>?schema</code>',
 			),
-			$this->option->get( 'enable_schema_endpoint' )
+			$this->option->get( 'enable_schema_endpoint' ),
 		);
 
 		return Form_Presenter::get_html( \__( 'Schema', 'yoast-test-helper' ), 'yoast_seo_test_schema', $output );

--- a/src/wordpress-plugin-features.php
+++ b/src/wordpress-plugin-features.php
@@ -34,7 +34,7 @@ class WordPress_Plugin_Features implements Integration {
 		foreach ( $this->plugins as $plugin ) {
 			\add_action(
 				'admin_post_' . $plugin->get_identifier() . '-feature-reset',
-				[ $this, 'handle_reset_feature' ]
+				[ $this, 'handle_reset_feature' ],
 			);
 		}
 	}
@@ -73,12 +73,12 @@ class WordPress_Plugin_Features implements Integration {
 						'<button id="%s" name="%s" type="submit" class="button secondary">' . \esc_html__( 'Reset', 'yoast-test-helper' ) . ' %s</button> ',
 						\esc_attr( $feature . '_button' ),
 						\esc_attr( $feature ),
-						\esc_html( $name )
+						\esc_html( $name ),
 					);
 				},
 				$features,
-				\array_keys( $features )
-			)
+				\array_keys( $features ),
+			),
 		);
 
 		return Form_Presenter::get_html( $plugin->get_name(), $action, $fields, false );
@@ -107,8 +107,8 @@ class WordPress_Plugin_Features implements Integration {
 
 		\wp_safe_redirect(
 			\self_admin_url(
-				'tools.php?page=' . \apply_filters( 'Yoast\WP\Test_Helper\admin_page', '' )
-			)
+				'tools.php?page=' . \apply_filters( 'Yoast\WP\Test_Helper\admin_page', '' ),
+			),
 		);
 	}
 
@@ -134,9 +134,9 @@ class WordPress_Plugin_Features implements Integration {
 					/* translators: %1$s expands to the plugin name, %2$s to the feature name. */
 					\esc_html__( '%1$s feature %2$s could not be reset.', 'yoast-test-helper' ),
 					$plugin->get_name(),
-					'<strong>' . $name . '</strong>'
+					'<strong>' . $name . '</strong>',
 				),
-				'error'
+				'error',
 			);
 
 			if ( $plugin->reset_feature( $feature ) ) {
@@ -145,9 +145,9 @@ class WordPress_Plugin_Features implements Integration {
 						/* translators: %1$s expands to the plugin name, %2$s to the feature name. */
 						\esc_html__( '%1$s feature %2$s has been reset.', 'yoast-test-helper' ),
 						$plugin->get_name(),
-						'<strong>' . $name . '</strong>'
+						'<strong>' . $name . '</strong>',
 					),
-					'success'
+					'success',
 				);
 			}
 

--- a/src/wordpress-plugin-options.php
+++ b/src/wordpress-plugin-options.php
@@ -91,8 +91,8 @@ class WordPress_Plugin_Options {
 		$result = $wpdb->get_col(
 			$wpdb->prepare(
 				"SELECT option_value FROM {$wpdb->options} WHERE option_name = %s",
-				$name
-			)
+				$name,
+			),
 		);
 
 		if ( empty( $result ) ) {

--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -207,7 +207,7 @@ class Yoast_SEO implements WordPress_Plugin {
 			[
 				'meta_key' => 'wp_yoast_notifications',
 				'user_id'  => \get_current_user_id(),
-			]
+			],
 		);
 
 		// Delete all muted notification settings.

--- a/src/xml-sitemaps.php
+++ b/src/xml-sitemaps.php
@@ -69,7 +69,7 @@ class XML_Sitemaps implements Integration {
 		$output  = Form_Presenter::create_checkbox(
 			'disable_xml_sitemap_cache',
 			\esc_html__( 'Disable the XML sitemaps cache.', 'yoast-test-helper' ),
-			$this->option->get( 'disable_xml_sitemap_cache' )
+			$this->option->get( 'disable_xml_sitemap_cache' ),
 		);
 		$output .= '<label for="xml_sitemap_entries">' . \esc_html__( 'Maximum entries per XML sitemap:', 'yoast-test-helper' ) . '</label>';
 		$output .= '<input type="number" size="5" value="' . $value . '" placeholder="' . $placeholder . '" name="xml_sitemap_entries" id="xml_sitemap_entries"/><br/>';


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Code modernization

## Relevant technical choices:

Since PHP 7.3, PHP allows for trailing commas in function calls.

Similar to trailing commas in multi-line arrays, having a comma after the last parameter in a multi-line function call will make the diff smaller if a new parameter is added at a later point in time, allowing reviewers to focus on what's actually changed.

For a single-line function call, no such advantage can be gained.

As this codebase has dropped support for PHP < 7.4 by now, we can apply this modernization in all multi-line function calls.

Ref:
* https://wiki.php.net/rfc/trailing-comma-function-calls


## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_