### PR TITLE
CS/QA: improvements for exit/die

### DIFF
--- a/src/plugin-toggler.php
+++ b/src/plugin-toggler.php
@@ -199,7 +199,7 @@ class Plugin_Toggler implements Integration {
 
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The util takes care of escaping.
 		echo WPSEO_Utils::format_json_encode( $response );
-		die();
+		exit();
 	}
 
 	/**

--- a/src/schema.php
+++ b/src/schema.php
@@ -92,7 +92,7 @@ class Schema implements Integration {
 
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- This is our self generated Schema, no need for escaping.
 		echo WPSEO_Utils::format_json_encode( \YoastSEO()->meta->for_current_page()->schema );
-		exit;
+		exit();
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Code consistency

## Relevant technical choices:

### CS/QA: prefer exit() over die() 

`die()` is an alias, let's use the canonical construct name instead.

### CS: always use parentheses for exit/die

## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_