### PR TITLE
feat(logger): add PSR-3 logger that captures wpseo_logger output

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -78,7 +78,7 @@ div.wpseo_test_block td {
     padding: 2px 3px;
 }
 
-div.wpseo_test_block button.button[type=submit]{
+div.wpseo_test_block button.button[type=submit] {
     margin-top: 12px !important;
 }
 
@@ -90,9 +90,13 @@ div.wpseo_test_block input[type=checkbox] {
     margin: 5px 10px 5px 0;
 }
 
-div.wpseo_test_block input[type=number]{
+div.wpseo_test_block input[type=number] {
     width: 80px;
     margin: 5px 0 5px 10px;
+}
+
+div.wpseo_test_block input[type=text] {
+    margin: 10px 0;
 }
 
 div.wpseo_test_block textarea {

--- a/src/form-presenter.php
+++ b/src/form-presenter.php
@@ -53,6 +53,28 @@ class Form_Presenter {
 	}
 
 	/**
+	 * Builds a text input element.
+	 *
+	 * @param string $option      The option to make a text input for.
+	 * @param string $label       The label for the input.
+	 * @param string $value       The current value.
+	 * @param string $placeholder The placeholder text.
+	 *
+	 * @return string The input & label HTML.
+	 */
+	public static function create_text_input( $option, $label, $value = '', $placeholder = '' ) {
+		$output  = \sprintf( '<label for="%1$s">%2$s</label>', \esc_attr( $option ), \esc_html( $label ) );
+		$output .= \sprintf(
+			'<input type="text" name="%1$s" id="%1$s" value="%2$s" placeholder="%3$s" class="regular-text"/><br/>',
+			\esc_attr( $option ),
+			\esc_attr( $value ),
+			\esc_attr( $placeholder ),
+		);
+
+		return $output;
+	}
+
+	/**
 	 * Builds a select element.
 	 *
 	 * @param string   $option   The option to make a checkbox for.

--- a/src/logger-integration.php
+++ b/src/logger-integration.php
@@ -1,0 +1,471 @@
+<?php
+
+namespace Yoast\WP\Test_Helper;
+
+use Yoast\WP\Test_Helper\Logger\Database_Log_Storage;
+use Yoast\WP\Test_Helper\Logger\File_Log_Storage;
+use Yoast\WP\Test_Helper\Logger\Log_Storage;
+use Yoast\WP\Test_Helper\Logger\Test_Helper_Logger;
+
+/**
+ * Captures logs forwarded through Yoast SEO's wpseo_logger filter to a configurable backend.
+ */
+class Logger_Integration implements Integration {
+
+	/**
+	 * Nonce action for the settings form.
+	 *
+	 * @var string
+	 */
+	private const SETTINGS_ACTION = 'yoast_test_helper_logger_settings';
+
+	/**
+	 * Nonce action for the clear button form.
+	 *
+	 * @var string
+	 */
+	private const CLEAR_ACTION = 'yoast_test_helper_logger_clear';
+
+	/**
+	 * Backend identifier for the database storage.
+	 *
+	 * @var string
+	 */
+	private const BACKEND_DATABASE = 'database';
+
+	/**
+	 * Backend identifier for the file storage.
+	 *
+	 * @var string
+	 */
+	private const BACKEND_FILE = 'file';
+
+	/**
+	 * Maximum number of entries shown in the popover viewer.
+	 *
+	 * @var int
+	 */
+	private const VIEWER_LIMIT = 1000;
+
+	/**
+	 * The shared option store.
+	 *
+	 * @var Option
+	 */
+	private $option;
+
+	/**
+	 * Constructs the integration.
+	 *
+	 * @param Option $option The shared option store.
+	 */
+	public function __construct( Option $option ) {
+		$this->option = $option;
+	}
+
+	/**
+	 * Registers WordPress hooks.
+	 *
+	 * The wpseo_logger filter is only registered when the prefixed PSR-3 classes shipped by
+	 * Yoast SEO are actually loaded — otherwise our logger class cannot be instantiated.
+	 *
+	 * @return void
+	 */
+	public function add_hooks() {
+		if ( $this->option->get( 'logger_enabled' ) && \class_exists( '\YoastSEO_Vendor\Psr\Log\AbstractLogger' ) ) {
+			\add_filter( 'wpseo_logger', [ $this, 'provide_logger' ] );
+		}
+
+		\add_action( 'admin_post_' . self::SETTINGS_ACTION, [ $this, 'handle_submit' ] );
+		\add_action( 'admin_post_' . self::CLEAR_ACTION, [ $this, 'handle_clear' ] );
+	}
+
+	/**
+	 * Provides the logger to Yoast SEO via the wpseo_logger filter.
+	 *
+	 * Sets up the active backend lazily so the table or file is only materialized when Yoast SEO
+	 * actually requests the logger.
+	 *
+	 * @return Test_Helper_Logger The replacement logger.
+	 */
+	public function provide_logger() {
+		$storage = $this->get_active_storage();
+		$storage->setup();
+
+		return new Test_Helper_Logger( $storage, $this->get_threshold() );
+	}
+
+	/**
+	 * Renders the admin block.
+	 *
+	 * @return string The HTML to render.
+	 */
+	public function get_controls() {
+		$backend_options = [
+			self::BACKEND_DATABASE => \esc_html__( 'Database table', 'yoast-test-helper' ),
+			self::BACKEND_FILE     => \esc_html__( 'File on disk', 'yoast-test-helper' ),
+		];
+
+		$level_options = [];
+		foreach ( Test_Helper_Logger::levels() as $level ) {
+			$level_options[ $level ] = \esc_html( \ucfirst( $level ) );
+		}
+
+		$fields  = Form_Presenter::create_checkbox(
+			'logger_enabled',
+			\esc_html__( 'Enable the Yoast SEO logger.', 'yoast-test-helper' ),
+			(bool) $this->option->get( 'logger_enabled' ),
+		);
+		$fields .= Form_Presenter::create_select(
+			'logger_level',
+			\esc_html__( 'Minimum level captured: ', 'yoast-test-helper' ),
+			$level_options,
+			$this->get_threshold(),
+		);
+		$fields .= Form_Presenter::create_select(
+			'logger_backend',
+			\esc_html__( 'Storage backend: ', 'yoast-test-helper' ),
+			$backend_options,
+			$this->get_backend(),
+		);
+		$fields .= '<div id="yoast_test_helper_logger_file_settings">';
+		$fields .= Form_Presenter::create_text_input(
+			'logger_file_path',
+			\esc_html__( 'File path (absolute, only used for the file backend): ', 'yoast-test-helper' ),
+			(string) $this->option->get( 'logger_file_path' ),
+		);
+		$fields .= '<p class="description" style="color:#b32d2e;"><strong>'
+			. \esc_html__( 'Warning:', 'yoast-test-helper' ) . '</strong> '
+			. \esc_html__( 'Pick a path that is not web-accessible. Anything under wp-content/uploads/ is served publicly on most hosts and will leak whatever Yoast SEO logs.', 'yoast-test-helper' )
+			. '</p>';
+		$fields .= '</div>';
+
+		$output  = Form_Presenter::get_html(
+			\__( 'Logger', 'yoast-test-helper' ),
+			self::SETTINGS_ACTION,
+			$fields,
+		);
+		$output .= $this->backend_toggle_script();
+		$output .= $this->render_viewer();
+
+		return $output;
+	}
+
+	/**
+	 * Inline script that hides backend-specific fields when they are not relevant for the active backend.
+	 *
+	 * @return string The `<script>` tag.
+	 */
+	private function backend_toggle_script() {
+		return '<script>
+			( function () {
+				const backend = document.getElementById( "logger_backend" );
+				const fileSettings = document.getElementById( "yoast_test_helper_logger_file_settings" );
+				if ( ! backend || ! fileSettings ) {
+					return;
+				}
+				function sync() {
+					fileSettings.style.display = backend.value === "' . self::BACKEND_FILE . '" ? "" : "none";
+				}
+				backend.addEventListener( "change", sync );
+				sync();
+			} )();
+		</script>';
+	}
+
+	/**
+	 * Persists the settings form.
+	 *
+	 * Writes every setting that was submitted; the file path is rejected on validation failure
+	 * but other settings still save.
+	 *
+	 * @return void
+	 */
+	public function handle_submit() {
+		if ( \check_admin_referer( self::SETTINGS_ACTION ) === false ) {
+			$this->redirect_back();
+			return;
+		}
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- Verified above.
+		$enabled = isset( $_POST['logger_enabled'] );
+
+		$backend = isset( $_POST['logger_backend'] ) ? \sanitize_key( \wp_unslash( $_POST['logger_backend'] ) ) : self::BACKEND_DATABASE;
+		if ( ! \in_array( $backend, [ self::BACKEND_DATABASE, self::BACKEND_FILE ], true ) ) {
+			$backend = self::BACKEND_DATABASE;
+		}
+
+		$level = isset( $_POST['logger_level'] ) ? \sanitize_key( \wp_unslash( $_POST['logger_level'] ) ) : 'debug';
+		if ( ! \in_array( $level, Test_Helper_Logger::levels(), true ) ) {
+			$level = 'debug';
+		}
+
+		$submitted_path = isset( $_POST['logger_file_path'] ) ? \trim( \sanitize_text_field( \wp_unslash( $_POST['logger_file_path'] ) ) ) : '';
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		$path_to_persist = (string) $this->option->get( 'logger_file_path' );
+		if ( $submitted_path !== $path_to_persist ) {
+			$validation_error = $this->validate_file_path( $submitted_path );
+			if ( $validation_error === null ) {
+				$path_to_persist = $submitted_path;
+			}
+			else {
+				if ( $backend === self::BACKEND_FILE ) {
+					$enabled = false;
+				}
+				\do_action( 'Yoast\WP\Test_Helper\notification', new Notification( $validation_error, 'error' ) );
+			}
+		}
+
+		$this->option->set( 'logger_enabled', $enabled );
+		$this->option->set( 'logger_backend', $backend );
+		$this->option->set( 'logger_level', $level );
+		$this->option->set( 'logger_file_path', $path_to_persist );
+
+		$this->redirect_back();
+	}
+
+	/**
+	 * Empties the active backend.
+	 *
+	 * @return void
+	 */
+	public function handle_clear() {
+		if ( \check_admin_referer( self::CLEAR_ACTION ) === false ) {
+			$this->redirect_back();
+			return;
+		}
+
+		$storage = $this->get_active_storage();
+		$storage->setup();
+		$storage->clear();
+
+		\do_action(
+			'Yoast\WP\Test_Helper\notification',
+			new Notification( \esc_html__( 'Cleared all captured logs.', 'yoast-test-helper' ), 'success' ),
+		);
+
+		$this->redirect_back();
+	}
+
+	/**
+	 * Builds the storage instance for the currently configured backend.
+	 *
+	 * Note: switching the backend does not migrate prior entries — by design.
+	 *
+	 * @return Log_Storage The active storage backend.
+	 */
+	private function get_active_storage() {
+		if ( $this->get_backend() === self::BACKEND_FILE ) {
+			return new File_Log_Storage( (string) $this->option->get( 'logger_file_path' ) );
+		}
+
+		return new Database_Log_Storage( $this->option );
+	}
+
+	/**
+	 * Returns the configured backend identifier, falling back to the database backend.
+	 *
+	 * @return string The backend identifier.
+	 */
+	private function get_backend() {
+		$backend = (string) $this->option->get( 'logger_backend' );
+		if ( ! \in_array( $backend, [ self::BACKEND_DATABASE, self::BACKEND_FILE ], true ) ) {
+			return self::BACKEND_DATABASE;
+		}
+
+		return $backend;
+	}
+
+	/**
+	 * Returns the configured level threshold, falling back to debug.
+	 *
+	 * @return string The PSR-3 level name.
+	 */
+	private function get_threshold() {
+		$level = (string) $this->option->get( 'logger_level' );
+		if ( ! \in_array( $level, Test_Helper_Logger::levels(), true ) ) {
+			return 'debug';
+		}
+
+		return $level;
+	}
+
+	/**
+	 * Validates a user-supplied absolute path.
+	 *
+	 * @param string $path The submitted path.
+	 *
+	 * @return string|null Translated error message on failure, or null on success.
+	 */
+	private function validate_file_path( $path ) {
+		if ( $path === '' ) {
+			// Empty paths are accepted; the file backend just won't be usable until one is set.
+			return null;
+		}
+
+		if ( $path[0] !== '/' && ! \preg_match( '/^[A-Za-z]:[\\\\\/]/', $path ) ) {
+			return \esc_html__( 'Logger file path must be absolute.', 'yoast-test-helper' );
+		}
+
+		foreach ( \explode( '/', \str_replace( '\\', '/', $path ) ) as $segment ) {
+			if ( $segment === '..' ) {
+				return \esc_html__( 'Logger file path may not contain ".." segments.', 'yoast-test-helper' );
+			}
+		}
+
+		$normalized      = \str_replace( '\\', '/', $path );
+		$forbidden_roots = [];
+		$uploads         = \wp_get_upload_dir();
+		if ( ! empty( $uploads['basedir'] ) ) {
+			$forbidden_roots[] = \str_replace( '\\', '/', $uploads['basedir'] );
+		}
+		if ( \defined( 'WP_CONTENT_DIR' ) ) {
+			$forbidden_roots[] = \str_replace( '\\', '/', \WP_CONTENT_DIR );
+		}
+		foreach ( $forbidden_roots as $root ) {
+			if ( $root !== '' && \strpos( $normalized, \rtrim( $root, '/' ) . '/' ) === 0 ) {
+				return \esc_html__( 'Logger file path may not be inside wp-content/ or the uploads directory; those locations are typically web-accessible.', 'yoast-test-helper' );
+			}
+		}
+
+		// phpcs:disable WordPress.WP.AlternativeFunctions.file_system_operations_is_writable -- Path validation requires direct filesystem checks; the WP_Filesystem API does not expose is_writable on arbitrary absolute paths.
+		$directory = \dirname( $path );
+		if ( ! \is_dir( $directory ) || ! \is_writable( $directory ) ) {
+			return \esc_html__( 'Logger file path is not writable.', 'yoast-test-helper' );
+		}
+
+		if ( \file_exists( $path ) && ! \is_writable( $path ) ) {
+			return \esc_html__( 'Logger file path is not writable.', 'yoast-test-helper' );
+		}
+		// phpcs:enable WordPress.WP.AlternativeFunctions.file_system_operations_is_writable
+
+		return null;
+	}
+
+	/**
+	 * Builds the viewer HTML: a compact summary, a "View log entries" button that opens a popover, and the Clear form.
+	 *
+	 * @return string The viewer HTML.
+	 */
+	private function render_viewer() {
+		// Read VIEWER_LIMIT + 1 so we can detect overflow and show "1000+" without counting the whole backend.
+		$entries  = $this->get_active_storage()->read( self::VIEWER_LIMIT + 1 );
+		$overflow = \count( $entries ) > self::VIEWER_LIMIT;
+		if ( $overflow ) {
+			$entries = \array_slice( $entries, 0, self::VIEWER_LIMIT );
+		}
+		$shown = \count( $entries );
+
+		$output  = '<h3>' . \esc_html__( 'Recent logs', 'yoast-test-helper' ) . '</h3>';
+		$output .= '<p>' . \esc_html( $this->captured_summary( $shown, $overflow ) ) . '</p>';
+
+		$output .= '<div style="display:flex;gap:1.5em;align-items:center;">';
+		if ( $shown > 0 ) {
+			$output .= '<button type="button" class="button-link" popovertarget="yoast_test_helper_logger_popover">'
+				. \esc_html__( 'View captured logs', 'yoast-test-helper' )
+				. '</button>';
+		}
+
+		$output .= '<form action="' . \esc_url( \admin_url( 'admin-post.php' ) ) . '" method="POST" style="display:inline;">';
+		$output .= \str_replace( 'id="_wpnonce"', '', \wp_nonce_field( self::CLEAR_ACTION, '_wpnonce', true, false ) );
+		$output .= '<input type="hidden" name="action" value="' . \esc_attr( self::CLEAR_ACTION ) . '">';
+		$output .= '<button class="button-link button-link-delete" type="submit">' . \esc_html__( 'Delete all captured logs', 'yoast-test-helper' ) . '</button>';
+		$output .= '</form>';
+		$output .= '</div>';
+
+		if ( $shown > 0 ) {
+			$output .= $this->render_viewer_popover( $entries );
+		}
+
+		return $output;
+	}
+
+	/**
+	 * Builds the "N logs captured" summary, marking the count as a lower bound when overflow was hit.
+	 *
+	 * @param int  $shown    Number of entries returned (capped at VIEWER_LIMIT).
+	 * @param bool $overflow True when the backend has more entries than the viewer cap.
+	 *
+	 * @return string The translated summary text.
+	 */
+	private function captured_summary( $shown, $overflow ) {
+		if ( $overflow ) {
+			return \sprintf(
+				/* translators: %d: viewer cap; the actual count is at least this many. */
+				\__( '%d+ logs captured. Showing the most recent ones.', 'yoast-test-helper' ),
+				self::VIEWER_LIMIT,
+			);
+		}
+
+		return \sprintf(
+			/* translators: %d: number of captured logs. */
+			\_n( '%d log captured.', '%d logs captured.', $shown, 'yoast-test-helper' ),
+			$shown,
+		);
+	}
+
+	/**
+	 * Builds the popover element with the full table inside.
+	 *
+	 * Uses the native HTML popover API: clicking the button (popovertarget) opens it, ESC and click-outside close it,
+	 * the close button uses popovertargetaction="hide". No JavaScript required.
+	 *
+	 * @param array<int, array{logged_at: string, level: string, message: string, context: array<string, scalar|array|object|null>}> $entries The entries to render.
+	 *
+	 * @return string The popover HTML.
+	 */
+	private function render_viewer_popover( array $entries ) {
+		$output  = '<div id="yoast_test_helper_logger_popover" popover style="width:90vw;max-width:1400px;height:90vh;padding:1em;border:1px solid #c3c4c7;">';
+		$output .= '<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:.5em;">';
+		$output .= '<h2 style="margin:0;">' . \esc_html__( 'Yoast SEO logs', 'yoast-test-helper' ) . '</h2>';
+		$output .= '<button type="button" class="button" popovertarget="yoast_test_helper_logger_popover" popovertargetaction="hide">'
+			. \esc_html__( 'Close', 'yoast-test-helper' )
+			. '</button>';
+		$output .= '</div>';
+
+		$output .= '<div style="overflow:auto;height:calc(90vh - 4em);">';
+		$output .= '<table class="widefat striped" style="table-layout:auto;">';
+		$output .= '<thead><tr>';
+		$output .= '<th style="width:11em;">' . \esc_html__( 'Time (UTC)', 'yoast-test-helper' ) . '</th>';
+		$output .= '<th style="width:6em;">' . \esc_html__( 'Level', 'yoast-test-helper' ) . '</th>';
+		$output .= '<th>' . \esc_html__( 'Message', 'yoast-test-helper' ) . '</th>';
+		$output .= '<th style="width:30%;">' . \esc_html__( 'Context', 'yoast-test-helper' ) . '</th>';
+		$output .= '</tr></thead><tbody>';
+
+		foreach ( $entries as $entry ) {
+			$context_json = '';
+			if ( ! empty( $entry['context'] ) ) {
+				// phpcs:ignore Yoast.Yoast.JsonEncodeAlternative.FoundWithAdditionalParams -- Pretty-printed output is needed for the admin viewer; format_json_encode does not accept flags.
+				$context_json = (string) \wp_json_encode( $entry['context'], ( \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES ) );
+			}
+
+			$output .= '<tr>';
+			$output .= '<td>' . \esc_html( $entry['logged_at'] ) . '</td>';
+			$output .= '<td>' . \esc_html( \strtoupper( $entry['level'] ) ) . '</td>';
+			$output .= '<td style="word-break:break-word;">' . \esc_html( $entry['message'] ) . '</td>';
+			$output .= '<td>';
+			if ( $context_json !== '' ) {
+				$output .= '<pre style="margin:0;white-space:pre-wrap;word-break:break-word;">' . \esc_html( $context_json ) . '</pre>';
+			}
+			$output .= '</td>';
+			$output .= '</tr>';
+		}
+
+		$output .= '</tbody></table>';
+		$output .= '</div></div>';
+
+		return $output;
+	}
+
+	/**
+	 * Sends the user back to the test helper admin page.
+	 *
+	 * @return void
+	 */
+	private function redirect_back() {
+		\wp_safe_redirect(
+			\self_admin_url( 'tools.php?page=' . \apply_filters( 'Yoast\WP\Test_Helper\admin_page', '' ) ),
+		);
+	}
+}

--- a/src/logger/database-log-storage.php
+++ b/src/logger/database-log-storage.php
@@ -1,0 +1,204 @@
+<?php
+
+namespace Yoast\WP\Test_Helper\Logger;
+
+use Yoast\WP\Test_Helper\Option;
+
+/**
+ * Stores log entries in a dedicated custom table.
+ */
+class Database_Log_Storage implements Log_Storage {
+
+	/**
+	 * Suffix for the custom table, appended to the WordPress table prefix.
+	 *
+	 * @var string
+	 */
+	public const TABLE_SUFFIX = 'yoast_test_helper_log';
+
+	/**
+	 * Schema version, used to short-circuit dbDelta on subsequent calls.
+	 *
+	 * @var string
+	 */
+	public const SCHEMA_VERSION = '1';
+
+	/**
+	 * Default maximum number of entries kept in the table.
+	 *
+	 * Callers can override the effective cap via the `Yoast\WP\Test_Helper\logger_max_rows` filter.
+	 *
+	 * @var int
+	 */
+	public const DEFAULT_MAX_ROWS = 1000;
+
+	/**
+	 * Option key tracking the last applied schema version.
+	 *
+	 * @var string
+	 */
+	private const SCHEMA_OPTION = 'logger_db_version';
+
+	/**
+	 * The shared option store, used to remember the applied schema version.
+	 *
+	 * @var Option
+	 */
+	private $option;
+
+	/**
+	 * Constructs the storage.
+	 *
+	 * @param Option $option The shared option store.
+	 */
+	public function __construct( Option $option ) {
+		$this->option = $option;
+	}
+
+	/**
+	 * Creates or upgrades the log table when the stored schema version is out of date.
+	 *
+	 * @return void
+	 */
+	public function setup() {
+		if ( $this->option->get( self::SCHEMA_OPTION ) === self::SCHEMA_VERSION ) {
+			return;
+		}
+
+		require_once \ABSPATH . 'wp-admin/includes/upgrade.php';
+
+		global $wpdb;
+		$table_name      = $this->get_table_name();
+		$charset_collate = $wpdb->get_charset_collate();
+
+		$sql = "CREATE TABLE {$table_name} (
+			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			logged_at DATETIME NOT NULL,
+			level VARCHAR(16) NOT NULL,
+			message TEXT NOT NULL,
+			context LONGTEXT NULL,
+			PRIMARY KEY  (id),
+			KEY logged_at (logged_at),
+			KEY level (level)
+		) {$charset_collate};";
+
+		\dbDelta( $sql );
+
+		$this->option->set( self::SCHEMA_OPTION, self::SCHEMA_VERSION );
+	}
+
+	/**
+	 * Inserts a log entry and trims the table to MAX_ROWS.
+	 *
+	 * @param string                                  $level     PSR-3 log level.
+	 * @param string                                  $message   The interpolated message.
+	 * @param array<string, scalar|array|object|null> $context   The original context array.
+	 * @param int                                     $timestamp Unix timestamp at which the entry was captured.
+	 *
+	 * @return void
+	 */
+	public function write( $level, $message, array $context, $timestamp ) {
+		global $wpdb;
+		$table_name = $this->get_table_name();
+
+		$wpdb->insert(
+			$table_name,
+			[
+				'logged_at' => \gmdate( 'Y-m-d H:i:s', $timestamp ),
+				'level'     => $level,
+				'message'   => $message,
+				// phpcs:ignore Yoast.Yoast.JsonEncodeAlternative.Found -- Compact storage; format_json_encode pretty-prints, which bloats the row.
+				'context'   => \wp_json_encode( $context ),
+			],
+			[ '%s', '%s', '%s', '%s' ],
+		);
+
+		$max_rows = (int) \apply_filters( 'Yoast\WP\Test_Helper\logger_max_rows', self::DEFAULT_MAX_ROWS );
+		if ( $max_rows < 1 ) {
+			return;
+		}
+
+		// Trim using a derived subquery — MySQL cannot otherwise reference the target table in a DELETE subquery.
+		$wpdb->query(
+			$wpdb->prepare(
+				'DELETE FROM %i WHERE id NOT IN (
+					SELECT id FROM ( SELECT id FROM %i ORDER BY id DESC LIMIT %d ) AS keep_ids
+				)',
+				$table_name,
+				$table_name,
+				$max_rows,
+			),
+		);
+	}
+
+	/**
+	 * Reads the most recent entries, newest first.
+	 *
+	 * @param int $limit Maximum number of entries to return.
+	 *
+	 * @return array<int, array{logged_at: string, level: string, message: string, context: array<string, scalar|array|object|null>}> The entries.
+	 */
+	public function read( $limit = 50 ) {
+		global $wpdb;
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT logged_at, level, message, context FROM %i ORDER BY id DESC LIMIT %d',
+				$this->get_table_name(),
+				(int) $limit,
+			),
+			\ARRAY_A,
+		);
+
+		if ( ! \is_array( $rows ) ) {
+			return [];
+		}
+
+		return \array_map( [ self::class, 'hydrate_row' ], $rows );
+	}
+
+	/**
+	 * Empties the log table.
+	 *
+	 * @return void
+	 */
+	public function clear() {
+		global $wpdb;
+		$wpdb->query(
+			$wpdb->prepare( 'TRUNCATE TABLE %i', $this->get_table_name() ),
+		);
+	}
+
+	/**
+	 * Converts a database row into the entry shape returned by read().
+	 *
+	 * @param array<string, scalar|array|object|null> $row The database row.
+	 *
+	 * @return array{logged_at: string, level: string, message: string, context: array<string, scalar|array|object|null>} The entry.
+	 */
+	private static function hydrate_row( array $row ) {
+		$context = [];
+		if ( isset( $row['context'] ) && $row['context'] !== '' ) {
+			$decoded = \json_decode( (string) $row['context'], true );
+			if ( \is_array( $decoded ) ) {
+				$context = $decoded;
+			}
+		}
+
+		return [
+			'logged_at' => (string) $row['logged_at'],
+			'level'     => (string) $row['level'],
+			'message'   => (string) $row['message'],
+			'context'   => $context,
+		];
+	}
+
+	/**
+	 * Builds the fully qualified table name.
+	 *
+	 * @return string The prefixed table name.
+	 */
+	private function get_table_name() {
+		global $wpdb;
+		return $wpdb->prefix . self::TABLE_SUFFIX;
+	}
+}

--- a/src/logger/file-log-storage.php
+++ b/src/logger/file-log-storage.php
@@ -1,0 +1,283 @@
+<?php
+// phpcs:disable WordPress.WP.AlternativeFunctions.file_system_operations_fopen,WordPress.WP.AlternativeFunctions.file_system_operations_fwrite,WordPress.WP.AlternativeFunctions.file_system_operations_fclose,WordPress.WP.AlternativeFunctions.file_system_operations_fread,WordPress.WP.AlternativeFunctions.file_system_operations_is_writable,WordPress.WP.AlternativeFunctions.file_system_operations_touch -- This is a file-backed logger; the WP_Filesystem API has no streaming flock/seek primitives.
+
+namespace Yoast\WP\Test_Helper\Logger;
+
+/**
+ * Stores log entries in a single append-only file.
+ *
+ * When the file grows beyond MAX_BYTES the oldest half is dropped on the next write.
+ */
+class File_Log_Storage implements Log_Storage {
+
+	/**
+	 * Maximum file size before the oldest half of the log is dropped, in bytes.
+	 *
+	 * @var int
+	 */
+	public const MAX_BYTES = 5_242_880;
+
+	/**
+	 * Read window used by tail() to find the last N lines, in bytes.
+	 *
+	 * @var int
+	 */
+	private const READ_CHUNK = 65_536;
+
+	/**
+	 * The absolute filesystem path to the log file.
+	 *
+	 * @var string
+	 */
+	private $path;
+
+	/**
+	 * Constructs the storage.
+	 *
+	 * @param string $path Absolute path to the log file.
+	 */
+	public function __construct( $path ) {
+		$this->path = (string) $path;
+	}
+
+	/**
+	 * Ensures the log file exists and is writable.
+	 *
+	 * @return void
+	 */
+	public function setup() {
+		if ( $this->path === '' ) {
+			return;
+		}
+
+		$directory = \dirname( $this->path );
+		if ( ! \is_dir( $directory ) || ! \is_writable( $directory ) ) {
+			return;
+		}
+
+		if ( ! \file_exists( $this->path ) ) {
+			\touch( $this->path );
+		}
+	}
+
+	/**
+	 * Appends a log entry to the file, rotating the file in half when it overflows.
+	 *
+	 * @param string                                  $level     PSR-3 log level.
+	 * @param string                                  $message   The interpolated message.
+	 * @param array<string, scalar|array|object|null> $context   The original context array.
+	 * @param int                                     $timestamp Unix timestamp at which the entry was captured.
+	 *
+	 * @return void
+	 */
+	public function write( $level, $message, array $context, $timestamp ) {
+		if ( $this->path === '' ) {
+			return;
+		}
+
+		// phpcs:ignore Yoast.Yoast.JsonEncodeAlternative.Found -- Compact storage; format_json_encode pretty-prints, which would inject newlines into the per-line file format.
+		$encoded = \wp_json_encode(
+			[
+				'logged_at' => \gmdate( 'Y-m-d H:i:s', $timestamp ),
+				'level'     => $level,
+				'message'   => $message,
+				'context'   => (object) $context,
+			],
+		);
+		if ( $encoded === false ) {
+			return;
+		}
+
+		$line = $encoded . "\n";
+
+		// Open in 'cb+' so the file is created if missing, but the position is at the start; we seek to end before writing.
+		// 'ab' would also open-for-append, but rotation needs a r/w handle that can both fseek+fread and ftruncate, so we use the same handle for both.
+		$handle = \fopen( $this->path, 'cb+' );
+		if ( $handle === false ) {
+			return;
+		}
+
+		try {
+			if ( ! \flock( $handle, \LOCK_EX ) ) {
+				return;
+			}
+
+			try {
+				\fseek( $handle, 0, \SEEK_END );
+				\fwrite( $handle, $line );
+				\fflush( $handle );
+
+				// Rotation runs under the same lock so racing writers block until it's done.
+				$size = (int) \ftell( $handle );
+				if ( $size > self::MAX_BYTES ) {
+					$this->rotate_locked( $handle, $size );
+				}
+			} finally {
+				\flock( $handle, \LOCK_UN );
+			}
+		} finally {
+			\fclose( $handle );
+		}
+	}
+
+	/**
+	 * Reads the most recent entries by tailing the file.
+	 *
+	 * @param int $limit Maximum number of entries to return.
+	 *
+	 * @return array<int, array{logged_at: string, level: string, message: string, context: array<string, scalar|array|object|null>}> The entries, newest first.
+	 */
+	public function read( $limit = 50 ) {
+		if ( $this->path === '' || ! \is_readable( $this->path ) ) {
+			return [];
+		}
+
+		$lines = $this->tail( (int) $limit );
+		if ( $lines === [] ) {
+			return [];
+		}
+
+		$entries = [];
+		foreach ( $lines as $line ) {
+			$line = \rtrim( $line, "\r\n" );
+			if ( $line === '' ) {
+				continue;
+			}
+
+			$decoded = \json_decode( $line, true );
+			if ( ! \is_array( $decoded ) || ! isset( $decoded['message'] ) ) {
+				$entries[] = [
+					'logged_at' => '',
+					'level'     => '',
+					'message'   => $line,
+					'context'   => [],
+				];
+				continue;
+			}
+
+			$context = [];
+			if ( isset( $decoded['context'] ) && \is_array( $decoded['context'] ) ) {
+				$context = $decoded['context'];
+			}
+
+			$entries[] = [
+				'logged_at' => isset( $decoded['logged_at'] ) ? (string) $decoded['logged_at'] : '',
+				'level'     => isset( $decoded['level'] ) ? \strtolower( (string) $decoded['level'] ) : '',
+				'message'   => (string) $decoded['message'],
+				'context'   => $context,
+			];
+		}
+
+		return \array_reverse( $entries );
+	}
+
+	/**
+	 * Empties the log file by truncating it under an exclusive lock.
+	 *
+	 * @return void
+	 */
+	public function clear() {
+		if ( $this->path === '' || ! \file_exists( $this->path ) ) {
+			return;
+		}
+
+		$handle = \fopen( $this->path, 'cb+' );
+		if ( $handle === false ) {
+			return;
+		}
+
+		try {
+			if ( ! \flock( $handle, \LOCK_EX ) ) {
+				return;
+			}
+
+			try {
+				\ftruncate( $handle, 0 );
+				\fflush( $handle );
+			} finally {
+				\flock( $handle, \LOCK_UN );
+			}
+		} finally {
+			\fclose( $handle );
+		}
+	}
+
+	/**
+	 * Drops the oldest half of the file by rewriting the trailing half-window.
+	 *
+	 * Caller must already hold LOCK_EX on $handle. The handle is left open and locked on return.
+	 *
+	 * @param resource $handle Open r+ handle to the log file.
+	 * @param int      $size   Current size of the file in bytes.
+	 *
+	 * @return void
+	 */
+	private function rotate_locked( $handle, $size ) {
+		\fseek( $handle, (int) ( $size / 2 ) );
+		// Drop the partial line at the cut point.
+		\fgets( $handle );
+		$keep = \stream_get_contents( $handle );
+		if ( $keep === false ) {
+			$keep = '';
+		}
+
+		\ftruncate( $handle, 0 );
+		\rewind( $handle );
+		\fwrite( $handle, $keep );
+		\fflush( $handle );
+	}
+
+	/**
+	 * Reads the last $limit lines from the file.
+	 *
+	 * Grows the read window until enough newlines are seen or the start of the file is reached.
+	 *
+	 * @param int $limit Maximum number of lines to return.
+	 *
+	 * @return string[] The lines, oldest first within the returned window.
+	 */
+	private function tail( $limit ) {
+		$size = (int) \filesize( $this->path );
+		if ( $size === 0 ) {
+			return [];
+		}
+
+		$handle = \fopen( $this->path, 'rb' );
+		if ( $handle === false ) {
+			return [];
+		}
+
+		$buffer   = '';
+		$lines    = [];
+		$position = $size;
+		$max_read = (int) self::MAX_BYTES;
+		$bytes_in = 0;
+
+		try {
+			$line_count = 0;
+			while ( $position > 0 && $line_count <= $limit && $bytes_in < $max_read ) {
+				$chunk_size = (int) \min( self::READ_CHUNK, $position );
+				$position  -= $chunk_size;
+				\fseek( $handle, $position );
+				$chunk      = (string) \fread( $handle, $chunk_size );
+				$bytes_in  += $chunk_size;
+				$buffer     = $chunk . $buffer;
+				$lines      = \explode( "\n", $buffer );
+				$line_count = \count( $lines );
+			}
+		} finally {
+			\fclose( $handle );
+		}
+
+		// Drop trailing empty entry produced by a final newline.
+		if ( $lines !== [] && \end( $lines ) === '' ) {
+			\array_pop( $lines );
+		}
+
+		if ( \count( $lines ) > $limit ) {
+			$lines = \array_slice( $lines, -$limit );
+		}
+
+		return $lines;
+	}
+}

--- a/src/logger/log-storage-interface.php
+++ b/src/logger/log-storage-interface.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Yoast\WP\Test_Helper\Logger;
+
+/**
+ * Storage backend for captured log entries.
+ */
+interface Log_Storage {
+
+	/**
+	 * Prepares the backend for writing (creates the table, ensures the file exists, etc.).
+	 *
+	 * @return void
+	 */
+	public function setup();
+
+	/**
+	 * Persists a single log entry.
+	 *
+	 * @param string                                  $level     PSR-3 log level.
+	 * @param string                                  $message   The interpolated message.
+	 * @param array<string, scalar|array|object|null> $context   The original context array.
+	 * @param int                                     $timestamp Unix timestamp at which the entry was captured.
+	 *
+	 * @return void
+	 */
+	public function write( $level, $message, array $context, $timestamp );
+
+	/**
+	 * Reads the most recent entries, newest first.
+	 *
+	 * @param int $limit Maximum number of entries to return.
+	 *
+	 * @return array<int, array{logged_at: string, level: string, message: string, context: array<string, scalar|array|object|null>}> The entries.
+	 */
+	public function read( $limit = 50 );
+
+	/**
+	 * Removes all entries from the backend.
+	 *
+	 * @return void
+	 */
+	public function clear();
+}

--- a/src/logger/test-helper-logger.php
+++ b/src/logger/test-helper-logger.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Yoast\WP\Test_Helper\Logger;
+
+use Throwable;
+use YoastSEO_Vendor\Psr\Log\AbstractLogger;
+use YoastSEO_Vendor\Psr\Log\LogLevel;
+
+/**
+ * PSR-3 logger that forwards entries above a configured threshold to a Log_Storage backend.
+ *
+ * Extends the prefixed PSR-3 classes shipped with Yoast SEO (YoastSEO_Vendor\Psr\Log) rather than
+ * stock psr/log, so the resulting object satisfies the interface that Yoast SEO's wpseo_logger
+ * filter is typed against. Loading this class therefore requires Yoast SEO to be active.
+ */
+class Test_Helper_Logger extends AbstractLogger {
+
+	/**
+	 * PSR-3 levels mapped to RFC 5424 severities for threshold comparison.
+	 *
+	 * @var array<string, int>
+	 */
+	private const LEVELS = [
+		LogLevel::DEBUG     => 0,
+		LogLevel::INFO      => 1,
+		LogLevel::NOTICE    => 2,
+		LogLevel::WARNING   => 3,
+		LogLevel::ERROR     => 4,
+		LogLevel::CRITICAL  => 5,
+		LogLevel::ALERT     => 6,
+		LogLevel::EMERGENCY => 7,
+	];
+
+	/**
+	 * The backend writes are forwarded to.
+	 *
+	 * @var Log_Storage
+	 */
+	private $storage;
+
+	/**
+	 * Numeric severity below which entries are dropped.
+	 *
+	 * @var int
+	 */
+	private $threshold;
+
+	/**
+	 * Constructs the logger.
+	 *
+	 * @param Log_Storage $storage   The backend writes are forwarded to.
+	 * @param string      $threshold PSR-3 level name; entries below this are dropped.
+	 */
+	public function __construct( Log_Storage $storage, $threshold ) {
+		$this->storage   = $storage;
+		$this->threshold = ( self::LEVELS[ $threshold ] ?? self::LEVELS[ LogLevel::DEBUG ] );
+	}
+
+	/**
+	 * Returns the list of supported PSR-3 level names, debug → emergency.
+	 *
+	 * @return string[] The level names.
+	 */
+	public static function levels() {
+		return \array_keys( self::LEVELS );
+	}
+
+	/**
+	 * Logs a single entry.
+	 *
+	 * @param string                                  $level   PSR-3 log level.
+	 * @param string                                  $message The message, with optional `{placeholder}` tokens.
+	 * @param array<string, scalar|array|object|null> $context Context replacements and supplementary data.
+	 *
+	 * @return void
+	 */
+	public function log( $level, $message, array $context = [] ) {
+		$level_name = (string) $level;
+		if ( ! isset( self::LEVELS[ $level_name ] ) ) {
+			return;
+		}
+
+		if ( self::LEVELS[ $level_name ] < $this->threshold ) {
+			return;
+		}
+
+		$interpolated = self::interpolate( (string) $message, $context );
+
+		try {
+			$this->storage->write( $level_name, $interpolated, $context, \time() );
+		} catch ( Throwable $e ) {
+			if ( \defined( 'WP_DEBUG' ) && \WP_DEBUG ) {
+				\error_log( 'Yoast Test Helper logger failed: ' . $e->getMessage() ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			}
+		}
+	}
+
+	/**
+	 * Substitutes `{placeholder}` tokens in the message per PSR-3 §1.2.
+	 *
+	 * Only scalar and `__toString`-able context values are substituted; other placeholders are left intact.
+	 *
+	 * @param string                                  $message The raw message.
+	 * @param array<string, scalar|array|object|null> $context The context array.
+	 *
+	 * @return string The interpolated message.
+	 */
+	private static function interpolate( $message, array $context ) {
+		if ( \strpos( $message, '{' ) === false ) {
+			return $message;
+		}
+
+		return (string) \preg_replace_callback(
+			'/\{([A-Za-z0-9_.]+)\}/',
+			static function ( array $matches ) use ( $context ) {
+				return self::resolve_placeholder( $matches, $context );
+			},
+			$message,
+		);
+	}
+
+	/**
+	 * Resolves a single `{placeholder}` match against the context array.
+	 *
+	 * Per PSR-3 §1.2 scalar and `__toString`-able values substitute directly. Non-scalar values
+	 * (arrays, plain objects, DateTime, etc.) get JSON-encoded so they still produce a useful
+	 * message — Monolog's LineFormatter does the same.
+	 *
+	 * @param array<int, string>                      $matches The regex match: full match, then the captured key.
+	 * @param array<string, scalar|array|object|null> $context The context array.
+	 *
+	 * @return string The replacement, or the original placeholder when nothing fits.
+	 */
+	private static function resolve_placeholder( array $matches, array $context ) {
+		$key = $matches[1];
+		if ( ! \array_key_exists( $key, $context ) ) {
+			return $matches[0];
+		}
+
+		$value = $context[ $key ];
+		if ( $value === null || \is_scalar( $value ) ) {
+			return (string) $value;
+		}
+
+		if ( \is_object( $value ) && \method_exists( $value, '__toString' ) ) {
+			return (string) $value;
+		}
+
+		// phpcs:ignore Yoast.Yoast.JsonEncodeAlternative.Found -- Inline interpolation needs compact JSON; format_json_encode pretty-prints, which breaks the single-line file format.
+		$encoded = \wp_json_encode( $value );
+		if ( $encoded !== false ) {
+			return $encoded;
+		}
+
+		return $matches[0];
+	}
+}

--- a/src/plugin.php
+++ b/src/plugin.php
@@ -91,6 +91,7 @@ class Plugin implements Integration {
 		$this->integrations[] = new Domain_Dropdown( $option );
 		$this->integrations[] = new Inline_Script( $option );
 		$this->integrations[] = new Admin_Debug_Info( $option );
+		$this->integrations[] = new Logger_Integration( $option );
 		$this->integrations[] = new Indexing_Reason_Integration();
 		$this->integrations[] = new Query_Monitor();
 		$this->integrations[] = new Downgrader();


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds a Logger panel to the Yoast Test Helper (Tools → Yoast Test) that replaces Yoast SEO's `NullLogger` via the `wpseo_logger` filter and persists captured entries to either a custom DB table or a JSONL file.

<img width="675" height="490" alt="image" src="https://github.com/user-attachments/assets/f23284bd-9396-4142-bc23-a8d97c33ffb3" />
<img width="1712" height="1048" alt="image" src="https://github.com/user-attachments/assets/67fb10cf-2b46-4688-87ee-cb6eb9c772e8" />


## Relevant technical choices

* **No new Composer dependency.** The logger extends `\YoastSEO_Vendor\Psr\Log\AbstractLogger` (Yoast SEO's prefixed copy) so the resulting object satisfies the same `LoggerInterface` Yoast SEO's filter is typed against. Filter registration is gated by `class_exists('\YoastSEO_Vendor\Psr\Log\AbstractLogger')` so the test helper does not fatal when Yoast SEO is inactive.
* **Two backends**, picked via dropdown: a dedicated `{prefix}yoast_test_helper_log` table created lazily via `dbDelta` on first use (capped at 1000 rows; cap is filterable through `Yoast\WP\Test_Helper\logger_max_rows`), or a JSONL file at a user-configurable absolute path (capped at 5MB with rotation by halving). The DB backend uses `%i` identifier placeholders so `$wpdb->prepare()` handles table-name escaping.
* **File-write concurrency**: `write()`, `clear()`, and rotation all happen under a single `flock(LOCK_EX)` per call, so concurrent writers don't lose data during rotation.
* **Path validation** rejects empty, non-absolute, `..`-containing, non-writable, *and* paths inside `WP_CONTENT_DIR` / the uploads directory — those are typically web-accessible. UI also shows an inline warning under the path field.
* **Configurable level threshold** (debug → emergency); entries below are dropped at capture time. PSR-3 §1.2 placeholder interpolation, with non-scalar context values JSON-encoded so `{date}`/`{list}`/`{object}` substitute meaningfully.
* **Viewer**: compact summary with a native HTML `<dialog popover>` for the full table — no JavaScript required for open/close/ESC. Capped at 1000 entries; renders "1000+ logs captured" when there's more behind the cap. View / Delete are link-style buttons (Delete is `button-link-delete`, red), keeping Save as the only primary CTA.
* **Backend toggle JS** (the only JS in this PR) hides the file-only fields when the database backend is selected.

## Milestone

* [ ] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged

This PR can be acceptance tested by following these steps:

1. Activate Yoast SEO and the Yoast Test Helper.
2. Visit Tools → Yoast Test. Confirm a new **Logger** block appears.
3. **Database backend**: enable the logger, leave backend = Database, level = Debug, save. Confirm the table exists: `wp db query "SHOW TABLES LIKE '%yoast_test_helper_log'"`.
4. Trigger a log call, e.g. `wp eval 'apply_filters("wpseo_logger", new \YoastSEO_Vendor\Psr\Log\NullLogger())->warning("hello {who}", ["who" => "world"]);'`.
5. Reload the panel; confirm "1 log captured." Click **View captured logs** — the popover shows the entry. Close it. Click **Delete all captured logs** — the table empties.
6. **File backend**: switch backend = File, set path to `/tmp/yoast-test-helper.log`, save. Repeat the `wp eval` from step 4. `tail /tmp/yoast-test-helper.log` shows one JSON line containing `"level":"warning"` and `"message":"hello world"`. Reload panel, confirm the viewer shows the entry. Click Delete — file truncates to 0 bytes.
7. **Threshold**: set level = Error, fire a `->warning(...)` and a `->critical(...)`. Only the critical entry persists.
8. **Invalid path**: backend = File, path = `/wp-content/uploads/anything.log`. Confirm an error notification renders, the path doesn't save, and the logger doesn't switch on.
9. **Backend toggle**: set backend = Database. Confirm the file path field and warning hide. Switch back to File. Confirm they reappear.
10. Run `composer check-cs-thresholds`; should pass at the existing baseline (32 errors, 0 warnings).

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

Fixes #87