### PR TITLE
MyYoast OAuth overrides: deliver staging/local credentials at runtime

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -68,6 +68,18 @@ div.wpseo_test_block button.button:hover {
     border-bottom-color: rgba(0, 0, 0, 0.2);
 }
 
+div.wpseo_test_block button.button:disabled,
+div.wpseo_test_block button.button[disabled],
+div.wpseo_test_block button.button:disabled:hover,
+div.wpseo_test_block button.button[disabled]:hover {
+    background-color: #dcdcde;
+    color: #50575e;
+    text-shadow: none;
+    box-shadow: none;
+    border-bottom-color: rgba(0, 0, 0, 0.1);
+    cursor: not-allowed;
+}
+
 div.wpseo_test_block button.button.secondary:hover {
     background-color: darkgray;
     color: black;

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -86,6 +86,10 @@ div.wpseo_test_block select {
     margin: 2px 5px;
 }
 
+div.wpseo_test_block input[type=text],
+div.wpseo_test_block input[type=url],
+div.wpseo_test_block input[type=password],
+div.wpseo_test_block input[type=email],
 div.wpseo_test_block input[type=checkbox] {
     margin: 5px 10px 5px 0;
 }
@@ -105,4 +109,49 @@ div.wpseo_test_block label {
 
 div.wpseo_test_block label code {
     font-size: 0.9em;
+}
+
+div.wpseo_test_block hr {
+    margin-top: 1.5em;
+}
+
+div.wpseo_test_block .wpseo_test_actions {
+    display: flex;
+    align-items: center;
+    gap: 1.5em;
+    margin-top: 0.5em;
+}
+
+dialog.wpseo_test_dialog {
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    padding: 1.5em 2em;
+    max-width: 90vw;
+    max-height: 80vh;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+}
+
+dialog.wpseo_test_dialog::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+}
+
+dialog.wpseo_test_dialog .wpseo_test_dialog_header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1em;
+}
+
+dialog.wpseo_test_dialog td {
+    padding-right: 1em;
+}
+
+dialog.wpseo_test_dialog .wpseo_test_dialog_close {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 1.4em;
+    line-height: 1;
+    color: #666;
+    padding: 0;
 }

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
 			"Yoast\\WP\\Test_Helper\\Config\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=32",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=30",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=0",
 			"Yoast\\WP\\Test_Helper\\Config\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/src/admin-page.php
+++ b/src/admin-page.php
@@ -122,10 +122,21 @@ class Admin_Page implements Integration {
 		<script type="text/javascript">
 			jQuery( window ).on( "load", function() {
 				var container = document.querySelector( "#yoast_masonry" );
-				new Masonry( container, {
+				var masonry   = new Masonry( container, {
 					itemSelector: ".wpseo_test_block",
 					columnWidth: ".wpseo_test_block"
 				} );
+
+				// Re-flow the masonry layout whenever any tile's content size changes,
+				// so integrations that show/hide rows don't need to know about masonry.
+				if ( typeof ResizeObserver === "function" ) {
+					var observer = new ResizeObserver( function() {
+						masonry.layout();
+					} );
+					Array.prototype.forEach.call( container.children, function( tile ) {
+						observer.observe( tile );
+					} );
+				}
 			} );
 		</script>
 		<?php

--- a/src/domain-dropdown.php
+++ b/src/domain-dropdown.php
@@ -144,7 +144,7 @@ class Domain_Dropdown implements Integration {
 	 * @return void
 	 */
 	public function handle_submit() {
-		if ( ! \check_admin_referer( 'yoast_seo_domain_dropdown' ) && ! isset( $_POST['myyoast_test_domain'] ) ) {
+		if ( ! \check_admin_referer( 'yoast_seo_domain_dropdown' ) ) {
 			return;
 		}
 

--- a/src/domain-dropdown.php
+++ b/src/domain-dropdown.php
@@ -165,8 +165,8 @@ class Domain_Dropdown implements Integration {
 	 * If a testing domain is set, modify any request to myYoast to go to the testing domain.
 	 * Attached to the `requests-requests.before_request` filter.
 	 *
-	 * @param string $url     URL of the request about to be made.
-	 * @param array  $headers Headers of the request about to be made.
+	 * @param string                                   $url     URL of the request about to be made.
+	 * @param array<string, string|array<int, string>> $headers Headers of the request about to be made.
 	 *
 	 * @return void
 	 */
@@ -193,9 +193,9 @@ class Domain_Dropdown implements Integration {
 	/**
 	 * Replace the domain of the url with the passed domain for my-yoast urls.
 	 *
-	 * @param string $domain  Testing domain to take place in the request.
-	 * @param string $url     URL of request about to be made.
-	 * @param array  $headers Headers of request about to be made.
+	 * @param string                                   $domain  Testing domain to take place in the request.
+	 * @param string                                   $url     URL of request about to be made.
+	 * @param array<string, string|array<int, string>> $headers Headers of request about to be made.
 	 *
 	 * @return array<string, string> Format: [ 'url' => new URL, 'host' => new Host ]
 	 */

--- a/src/domain-dropdown.php
+++ b/src/domain-dropdown.php
@@ -115,7 +115,7 @@ class Domain_Dropdown implements Integration {
 		}
 
 		$select_options                        = self::PREDEFINED_DOMAINS;
-		$select_options[ self::DOMAIN_CUSTOM ] = \__( 'Custom URL…', 'yoast-test-helper' );
+		$select_options[ self::DOMAIN_CUSTOM ] = \esc_html__( 'Custom URL…', 'yoast-test-helper' );
 
 		$output = Form_Presenter::create_select(
 			'myyoast_test_domain',
@@ -154,7 +154,7 @@ class Domain_Dropdown implements Integration {
 		}
 
 		if ( isset( $_POST['myyoast_test_custom_domain'] ) && \is_string( $_POST['myyoast_test_custom_domain'] ) ) {
-			$custom = \esc_url_raw( \wp_unslash( $_POST['myyoast_test_custom_domain'] ) );
+			$custom = $this->normalize_custom_domain( \esc_url_raw( \wp_unslash( $_POST['myyoast_test_custom_domain'] ) ) );
 			$this->option->set( 'myyoast_test_custom_domain', $custom );
 		}
 
@@ -217,6 +217,36 @@ class Domain_Dropdown implements Integration {
 			'url'  => $url,
 			'host' => $host,
 		];
+	}
+
+	/**
+	 * Normalizes a custom domain to scheme + host (+ optional port). Strips any
+	 * path, query, fragment, and trailing slash so the value can safely be used
+	 * as both the URL-rewrite base and the OAuth issuer key without producing
+	 * double-paths or split per-issuer credential records.
+	 *
+	 * Returns an empty string when the input doesn't parse to scheme + host.
+	 *
+	 * @param string $url The raw user input (already passed through esc_url_raw).
+	 *
+	 * @return string The normalized origin, or an empty string when invalid.
+	 */
+	private function normalize_custom_domain( $url ) {
+		if ( $url === '' ) {
+			return '';
+		}
+
+		$parts = \wp_parse_url( $url );
+		if ( ! \is_array( $parts ) || empty( $parts['scheme'] ) || empty( $parts['host'] ) ) {
+			return '';
+		}
+
+		$origin = $parts['scheme'] . '://' . $parts['host'];
+		if ( isset( $parts['port'] ) ) {
+			$origin .= ':' . $parts['port'];
+		}
+
+		return $origin;
 	}
 
 	/**

--- a/src/domain-dropdown.php
+++ b/src/domain-dropdown.php
@@ -33,13 +33,13 @@ class Domain_Dropdown implements Integration {
 	 * @var array<string, string>
 	 */
 	private const PREDEFINED_DOMAINS = [
-		self::DEFAULT_DOMAIN                 => 'live',
-		'https://staging.yoast.com'          => 'staging',
-		'https://staging-plugins.yoast.com'  => 'staging-plugins',
-		'https://staging-platform.yoast.com' => 'staging-platform',
-		'https://staging-4-my.yoast.com'     => 'staging-4',
-		'https://staging-5-my.yoast.com'     => 'staging-5',
-		'http://my.yoast.test'               => 'local',
+		self::DEFAULT_DOMAIN                    => 'live',
+		'https://staging-my.yoast.com'          => 'staging',
+		'https://staging-plugins-my.yoast.com'  => 'staging-plugins',
+		'https://staging-platform-my.yoast.com' => 'staging-platform',
+		'https://staging-4-my.yoast.com'        => 'staging-4',
+		'https://staging-5-my.yoast.com'        => 'staging-5',
+		'http://my.yoast.test'                  => 'local',
 	];
 
 	/**

--- a/src/domain-dropdown.php
+++ b/src/domain-dropdown.php
@@ -4,8 +4,43 @@ namespace Yoast\WP\Test_Helper;
 
 /**
  * Sends myYoast requests to a chosen testing domain.
+ *
+ * Owns the active MyYoast environment selection for the entire test helper.
+ * Other integrations (e.g. MyYoast_OAuth_Overrides) read the selected domain
+ * via {@see self::get_active_domain()} so that the dropdown stays the single
+ * source of truth for "which environment am I pointed at?".
  */
 class Domain_Dropdown implements Integration {
+
+	/**
+	 * The default production domain. When this is the active value the integration
+	 * is effectively a no-op — outgoing requests are not rewritten.
+	 *
+	 * @var string
+	 */
+	public const DEFAULT_DOMAIN = 'https://my.yoast.com';
+
+	/**
+	 * Sentinel value selected from the dropdown to mean "use the custom URL field".
+	 *
+	 * @var string
+	 */
+	private const DOMAIN_CUSTOM = 'custom';
+
+	/**
+	 * Predefined MyYoast environments.
+	 *
+	 * @var array<string, string>
+	 */
+	private const PREDEFINED_DOMAINS = [
+		self::DEFAULT_DOMAIN                 => 'live',
+		'https://staging.yoast.com'          => 'staging',
+		'https://staging-plugins.yoast.com'  => 'staging-plugins',
+		'https://staging-platform.yoast.com' => 'staging-platform',
+		'https://staging-4-my.yoast.com'     => 'staging-4',
+		'https://staging-5-my.yoast.com'     => 'staging-5',
+		'http://my.yoast.test'               => 'local',
+	];
 
 	/**
 	 * Holds our option instance.
@@ -24,6 +59,28 @@ class Domain_Dropdown implements Integration {
 	}
 
 	/**
+	 * Returns the active MyYoast domain — the resolved value of whichever entry
+	 * (predefined or custom) the user picked. Other integrations should read this
+	 * rather than peeking at the underlying option keys.
+	 *
+	 * @return string The active domain URL, or the production default when nothing is configured.
+	 */
+	public function get_active_domain() {
+		$selected = $this->option->get( 'myyoast_test_domain' );
+		if ( ! \is_string( $selected ) || $selected === '' ) {
+			return self::DEFAULT_DOMAIN;
+		}
+
+		if ( $selected === self::DOMAIN_CUSTOM ) {
+			$custom = $this->option->get( 'myyoast_test_custom_domain' );
+
+			return ( \is_string( $custom ) && $custom !== '' ) ? $custom : self::DEFAULT_DOMAIN;
+		}
+
+		return ( isset( self::PREDEFINED_DOMAINS[ $selected ] ) ) ? $selected : self::DEFAULT_DOMAIN;
+	}
+
+	/**
 	 * Registers WordPress hooks.
 	 *
 	 * @return void
@@ -31,8 +88,7 @@ class Domain_Dropdown implements Integration {
 	public function add_hooks() {
 		\add_action( 'admin_post_yoast_seo_domain_dropdown', [ $this, 'handle_submit' ] );
 
-		$domain = $this->option->get( 'myyoast_test_domain' );
-		if ( ! empty( $domain ) && $domain !== 'https://my.yoast.com' ) {
+		if ( $this->get_active_domain() !== self::DEFAULT_DOMAIN ) {
 			\add_action( 'requests-requests.before_request', [ $this, 'modify_myyoast_request' ], 10, 2 );
 		}
 		else {
@@ -46,20 +102,38 @@ class Domain_Dropdown implements Integration {
 	 * @return string The HTML to use to render the controls.
 	 */
 	public function get_controls() {
-		$select_options = [
-			'https://my.yoast.com'                  => 'live',
-			'https://staging-my.yoast.com'          => 'staging',
-			'https://staging-plugins-my.yoast.com'  => 'staging-plugins',
-			'https://staging-platform-my.yoast.com' => 'staging-platform',
-			'http://my.yoast.test:3000'             => 'local',
-		];
+		$stored        = $this->option->get( 'myyoast_test_domain' );
+		$custom        = $this->option->get( 'myyoast_test_custom_domain' );
+		$is_predefined = \is_string( $stored ) && isset( self::PREDEFINED_DOMAINS[ $stored ] );
+
+		$dropdown_value = '';
+		if ( $is_predefined ) {
+			$dropdown_value = $stored;
+		}
+		elseif ( $stored === self::DOMAIN_CUSTOM ) {
+			$dropdown_value = self::DOMAIN_CUSTOM;
+		}
+
+		$select_options                        = self::PREDEFINED_DOMAINS;
+		$select_options[ self::DOMAIN_CUSTOM ] = \__( 'Custom URL…', 'yoast-test-helper' );
 
 		$output = Form_Presenter::create_select(
 			'myyoast_test_domain',
-			\esc_html__( 'Set the myYoast testing domain to: ', 'yoast-test-helper' ),
+			\esc_html__( 'Set the MyYoast testing domain to: ', 'yoast-test-helper' ),
 			$select_options,
-			$this->option->get( 'myyoast_test_domain' ),
+			$dropdown_value,
 		);
+
+		$custom_value  = \is_string( $custom ) ? $custom : '';
+		$custom_hidden = ( $dropdown_value === self::DOMAIN_CUSTOM ) ? '' : ' hidden';
+		$output       .= \sprintf(
+			'<div id="myyoast_test_custom_domain_row"%1$s><label for="myyoast_test_custom_domain">%2$s</label> <input type="url" size="30" id="myyoast_test_custom_domain" name="myyoast_test_custom_domain" value="%3$s" placeholder="https://my.yoast.test"/><br/></div>',
+			$custom_hidden,
+			\esc_html__( 'Custom MyYoast URL:', 'yoast-test-helper' ),
+			\esc_attr( $custom_value ),
+		);
+
+		$output .= $this->render_custom_toggle_script();
 
 		return Form_Presenter::get_html( \__( 'Domain Dropdown', 'yoast-test-helper' ), 'yoast_seo_domain_dropdown', $output );
 	}
@@ -75,8 +149,13 @@ class Domain_Dropdown implements Integration {
 		}
 
 		if ( isset( $_POST['myyoast_test_domain'] ) && \is_string( $_POST['myyoast_test_domain'] ) ) {
-			$myyoast_test_domain = \sanitize_text_field( \wp_unslash( $_POST['myyoast_test_domain'] ) );
-			$this->option->set( 'myyoast_test_domain', $myyoast_test_domain );
+			$selected = \sanitize_text_field( \wp_unslash( $_POST['myyoast_test_domain'] ) );
+			$this->option->set( 'myyoast_test_domain', $selected );
+		}
+
+		if ( isset( $_POST['myyoast_test_custom_domain'] ) && \is_string( $_POST['myyoast_test_custom_domain'] ) ) {
+			$custom = \esc_url_raw( \wp_unslash( $_POST['myyoast_test_custom_domain'] ) );
+			$this->option->set( 'myyoast_test_custom_domain', $custom );
 		}
 
 		\wp_safe_redirect( \self_admin_url( 'tools.php?page=' . \apply_filters( 'Yoast\WP\Test_Helper\admin_page', '' ) ) );
@@ -92,9 +171,9 @@ class Domain_Dropdown implements Integration {
 	 * @return void
 	 */
 	public function modify_myyoast_request( &$url, &$headers ) {
-		$domain = $this->option->get( 'myyoast_test_domain' );
+		$domain = $this->get_active_domain();
 
-		if ( empty( $domain ) || $domain === 'https://my.yoast.com' ) {
+		if ( $domain === self::DEFAULT_DOMAIN ) {
 			return;
 		}
 
@@ -138,5 +217,29 @@ class Domain_Dropdown implements Integration {
 			'url'  => $url,
 			'host' => $host,
 		];
+	}
+
+	/**
+	 * Inline script that toggles the custom domain row based on the dropdown value.
+	 *
+	 * @return string The script tag HTML.
+	 */
+	private function render_custom_toggle_script() {
+		return <<<'HTML'
+<script>
+( function() {
+	var select = document.getElementById( "myyoast_test_domain" );
+	var row    = document.getElementById( "myyoast_test_custom_domain_row" );
+	if ( ! select || ! row ) {
+		return;
+	}
+	var sync = function() {
+		row.toggleAttribute( "hidden", select.value !== "custom" );
+	};
+	select.addEventListener( "change", sync );
+	sync();
+} )();
+</script>
+HTML;
 	}
 }

--- a/src/myyoast-oauth-overrides.php
+++ b/src/myyoast-oauth-overrides.php
@@ -104,9 +104,11 @@ class MyYoast_OAuth_Overrides implements Integration {
 	/**
 	 * Filters the MyYoast issuer URL.
 	 *
+	 * @param string $value The default issuer URL. Ignored — the active environment always wins.
+	 *
 	 * @return string The active environment URL.
 	 */
-	public function filter_issuer_url() {
+	public function filter_issuer_url( $value ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Filter signature requires the parameter; the active environment always wins.
 		return $this->get_active_issuer();
 	}
 
@@ -228,7 +230,7 @@ This wipes the local OAuth client state for the active issuer:
 	private function render_action_form( $action, $label, $disabled, $is_link, $confirm_message = '' ) {
 		$attrs       = ( $disabled ) ? ' disabled="disabled"' : '';
 		$button_attr = ( $is_link ) ? 'class="button-link button-link-delete"' : 'class="button"';
-		$onsubmit    = ( $confirm_message === '' ) ? '' : ' onsubmit="return confirm(' . \esc_attr( WPSEO_Utils::format_json_encode( $confirm_message ) ) . ')"';
+		$onsubmit    = ( $confirm_message === '' ) ? '' : ' onsubmit="' . \esc_attr( 'return confirm("' . \esc_js( $confirm_message ) . '")' ) . '"';
 
 		$output  = '<form action="' . \esc_url( \admin_url( 'admin-post.php' ) ) . '" method="POST"' . $onsubmit . '>';
 		$output .= \str_replace( 'id="_wpnonce"', '', \wp_nonce_field( $action, '_wpnonce', true, false ) );
@@ -351,7 +353,7 @@ This wipes the local OAuth client state for the active issuer:
 				\sprintf(
 					/* translators: %s expands to the WordPress error message. */
 					\esc_html__( 'Could not reach the credentials endpoint: %s', 'yoast-test-helper' ),
-					$response->get_error_message(),
+					\esc_html( $response->get_error_message() ),
 				),
 				'error',
 			);
@@ -663,5 +665,6 @@ This wipes the local OAuth client state for the active issuer:
 	 */
 	private function redirect() {
 		\wp_safe_redirect( \self_admin_url( 'tools.php?page=' . \apply_filters( 'Yoast\WP\Test_Helper\admin_page', '' ) ) );
+		exit();
 	}
 }

--- a/src/myyoast-oauth-overrides.php
+++ b/src/myyoast-oauth-overrides.php
@@ -163,9 +163,12 @@ class MyYoast_OAuth_Overrides implements Integration {
 			$fields .= '<p><em>' . \esc_html__( 'No overrides apply on production — Yoast SEO ships with valid baked-in credentials. Switch the Domain Dropdown to a non-production environment to configure credentials here.', 'yoast-test-helper' ) . '</em></p>';
 		}
 
-		$fields         .= \sprintf(
-			'<label for="myyoast_oauth_pat">%1$s</label> <input type="password" size="40" id="myyoast_oauth_pat" name="myyoast_oauth_pat" value="" autocomplete="off" placeholder="myp_••••••••"/><br/>',
+		$stored_pat = isset( $credentials['pat'] ) ? (string) $credentials['pat'] : '';
+		$pat_value  = ( $stored_pat === '' ) ? '' : $this->mask_pat( $stored_pat );
+		$fields    .= \sprintf(
+			'<label for="myyoast_oauth_pat">%1$s</label> <input type="text" size="40" id="myyoast_oauth_pat" name="myyoast_oauth_pat" value="%2$s" autocomplete="off" placeholder="myp_••••••••"/><br/>',
 			\esc_html__( 'MyYoast PAT for this environment:', 'yoast-test-helper' ),
+			\esc_attr( $pat_value ),
 		);
 
 		$output = Form_Presenter::get_html(
@@ -302,10 +305,10 @@ This wipes the local OAuth client state for the active issuer:
 
 		// phpcs:disable WordPress.Security.NonceVerification.Missing -- Nonce is verified above.
 		if ( isset( $_POST['myyoast_oauth_pat'] ) && \is_string( $_POST['myyoast_oauth_pat'] ) ) {
-			$pat    = \trim( \sanitize_text_field( \wp_unslash( $_POST['myyoast_oauth_pat'] ) ) );
-			$issuer = $this->get_active_issuer();
-			if ( $pat !== '' && ! $this->is_production( $issuer ) ) {
-				$this->store_credential_field( $issuer, 'pat', $pat );
+			$submitted = \trim( \sanitize_text_field( \wp_unslash( $_POST['myyoast_oauth_pat'] ) ) );
+			$issuer    = $this->get_active_issuer();
+			if ( $submitted !== '' && ! $this->is_production( $issuer ) && ! $this->is_masked_existing_pat( $issuer, $submitted ) ) {
+				$this->store_credential_field( $issuer, 'pat', $submitted );
 			}
 		}
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
@@ -566,6 +569,57 @@ This wipes the local OAuth client state for the active issuer:
 		$credentials = $this->get_active_credentials();
 
 		return ! empty( $credentials['pat'] );
+	}
+
+	/**
+	 * Builds the masked display form of a PAT: the public prefix (everything up
+	 * through the second underscore) followed by 8 asterisks. MyYoast surfaces
+	 * the same public prefix in its UI, so the developer can match what they
+	 * see here against the PAT in their MyYoast account.
+	 *
+	 * Falls back to a generic mask when the PAT doesn't follow the expected
+	 * `<prefix>_<id>_<secret>` format.
+	 *
+	 * @param string $pat The full PAT.
+	 *
+	 * @return string The masked representation.
+	 */
+	private function mask_pat( $pat ) {
+		$first = \strpos( $pat, '_' );
+		if ( $first === false ) {
+			return \str_repeat( '*', 8 );
+		}
+
+		$second = \strpos( $pat, '_', ( $first + 1 ) );
+		if ( $second === false ) {
+			return \str_repeat( '*', 8 );
+		}
+
+		return \substr( $pat, 0, ( $second + 1 ) ) . \str_repeat( '*', 8 );
+	}
+
+	/**
+	 * Returns whether the submitted PAT value is the masked representation of
+	 * the PAT already stored for the given issuer — i.e. the user did not edit
+	 * the prefilled field and we should not overwrite the stored value.
+	 *
+	 * @param string $issuer    The issuer URL.
+	 * @param string $submitted The PAT value as submitted from the form.
+	 *
+	 * @return bool True when the submission matches the masked stored PAT.
+	 */
+	private function is_masked_existing_pat( $issuer, $submitted ) {
+		$store = $this->option->get( 'myyoast_oauth_credentials' );
+		if ( ! \is_array( $store ) || ! isset( $store[ $issuer ] ) || ! \is_array( $store[ $issuer ] ) ) {
+			return false;
+		}
+
+		$stored = isset( $store[ $issuer ]['pat'] ) ? (string) $store[ $issuer ]['pat'] : '';
+		if ( $stored === '' ) {
+			return false;
+		}
+
+		return $submitted === $this->mask_pat( $stored );
 	}
 
 	/**

--- a/src/myyoast-oauth-overrides.php
+++ b/src/myyoast-oauth-overrides.php
@@ -1,0 +1,689 @@
+<?php
+
+namespace Yoast\WP\Test_Helper;
+
+use WP_Error;
+use WPSEO_Utils;
+
+/**
+ * Lets a developer point the Yoast SEO MyYoast OAuth client at a non-production
+ * issuer (staging, local) by overriding the `wpseo_myyoast_issuer_url`,
+ * `wpseo_myyoast_software_statement`, and `wpseo_myyoast_initial_access_token`
+ * filters.
+ *
+ * Instead of taking a raw software statement and initial access token by hand,
+ * the developer enters a MyYoast Personal Access Token (PAT) for the chosen
+ * issuer and the helper fetches a fresh SS+IAT pair from
+ * `{issuer}/api/oauth/software-statements` (the same endpoint the
+ * `update-myyoast-credentials` Grunt task uses at artifact-build time).
+ *
+ * PATs and credential pairs are persisted per issuer URL so a developer can
+ * keep credentials for multiple environments side-by-side and switch without
+ * re-pasting.
+ */
+class MyYoast_OAuth_Overrides implements Integration {
+
+	/**
+	 * The action name used to wipe all local OAuth state in Yoast SEO.
+	 *
+	 * @var string
+	 */
+	private const CLEAR_STATE_ACTION = 'wpseo_myyoast_clear_client_state';
+
+	/**
+	 * The path under the chosen issuer URL that mints SS+IAT pairs.
+	 *
+	 * @var string
+	 */
+	private const CREDENTIALS_PATH = '/api/oauth/software-statements';
+
+	/**
+	 * Static claims sent in the SS request body. Mirrors `SOFTWARE_STATEMENT_CLAIMS`
+	 * in `update-myyoast-credentials.js`.
+	 *
+	 * @var array<string, string|bool|array<int, string>>
+	 */
+	private const STATEMENT_CLAIMS = [
+		'softwareId'              => 'yoast/wordpress-seo',
+		'clientName'              => 'Yoast SEO',
+		'logoUri'                 => 'https://yoast.com/app/uploads/2025/11/premium.svg',
+		'clientUri'               => 'https://yoast.com/wordpress/plugins/seo/',
+		'tosUri'                  => 'https://yoast.com/terms-of-service/',
+		'policyUri'               => 'https://yoast.com/privacy-policy/',
+		'contacts'                => [ 'support@yoast.com' ],
+		'cleanupWhenInactive'     => true,
+		'tokenEndpointAuthMethod' => 'private_key_jwt',
+	];
+
+	/**
+	 * Sentinel value selected from the issuer dropdown to mean "use the custom URL".
+	 *
+	 * @var string
+	 */
+	private const ISSUER_CUSTOM = 'custom';
+
+	/**
+	 * Predefined issuer URLs, mirroring the Domain_Dropdown set.
+	 *
+	 * @var array<string, string>
+	 */
+	private const PREDEFINED_ISSUERS = [
+		'https://my.yoast.com'                  => 'live',
+		'https://staging.yoast.com'             => 'staging',
+		'https://staging-plugins.yoast.com'     => 'staging-plugins',
+		'https://staging-platform.yoast.com'    => 'staging-platform',
+		'https://staging-4-my.yoast.com'        => 'staging-4',
+		'https://staging-5-my.yoast.com'        => 'staging-5',
+		'http://my.yoast.test'                  => 'local',
+	];
+
+	/**
+	 * Holds our option instance.
+	 *
+	 * @var Option
+	 */
+	private $option;
+
+	/**
+	 * Class constructor.
+	 *
+	 * @param Option $option Our option array.
+	 */
+	public function __construct( Option $option ) {
+		$this->option = $option;
+	}
+
+	/**
+	 * Registers WordPress hooks and filters.
+	 *
+	 * @return void
+	 */
+	public function add_hooks() {
+		if ( $this->option->get( 'myyoast_oauth_overrides_enabled' ) ) {
+			\add_filter( 'wpseo_myyoast_issuer_url', [ $this, 'filter_issuer_url' ] );
+			\add_filter( 'wpseo_myyoast_software_statement', [ $this, 'filter_software_statement' ] );
+			\add_filter( 'wpseo_myyoast_initial_access_token', [ $this, 'filter_initial_access_token' ] );
+		}
+
+		\add_action( 'admin_post_yoast_test_myyoast_oauth_save', [ $this, 'handle_save' ] );
+		\add_action( 'admin_post_yoast_test_myyoast_oauth_fetch', [ $this, 'handle_fetch' ] );
+		\add_action( 'admin_post_yoast_test_myyoast_oauth_clear_client', [ $this, 'handle_clear_client' ] );
+	}
+
+	/**
+	 * Filters the MyYoast issuer URL.
+	 *
+	 * @param string $value The default issuer URL.
+	 *
+	 * @return string The active issuer URL when one is configured, the original value otherwise.
+	 */
+	public function filter_issuer_url( $value ) {
+		$issuer = $this->get_active_issuer();
+		if ( $issuer === '' ) {
+			return $value;
+		}
+
+		return $issuer;
+	}
+
+	/**
+	 * Filters the MyYoast software statement.
+	 *
+	 * @param string $value The default software statement.
+	 *
+	 * @return string The stored software statement when one is configured, the original value otherwise.
+	 */
+	public function filter_software_statement( $value ) {
+		$credentials = $this->get_active_credentials();
+		if ( empty( $credentials['software_statement'] ) ) {
+			return $value;
+		}
+
+		return $credentials['software_statement'];
+	}
+
+	/**
+	 * Filters the MyYoast initial access token.
+	 *
+	 * @param string $value The default initial access token.
+	 *
+	 * @return string The stored initial access token when one is configured, the original value otherwise.
+	 */
+	public function filter_initial_access_token( $value ) {
+		$credentials = $this->get_active_credentials();
+		if ( empty( $credentials['initial_access_token'] ) ) {
+			return $value;
+		}
+
+		return $credentials['initial_access_token'];
+	}
+
+	/**
+	 * Retrieves the controls.
+	 *
+	 * @return string The HTML to use to render the controls.
+	 */
+	public function get_controls() {
+		$enabled       = (bool) $this->option->get( 'myyoast_oauth_overrides_enabled' );
+		$active_issuer = $this->get_active_issuer();
+		$is_predefined = ( $active_issuer !== '' && isset( self::PREDEFINED_ISSUERS[ $active_issuer ] ) );
+		$selected      = ( $is_predefined ) ? $active_issuer : '';
+		$custom_issuer = ( $active_issuer !== '' && ! $is_predefined ) ? $active_issuer : '';
+		$has_pat       = $this->has_active_pat();
+		$credentials   = $this->get_active_credentials();
+
+		$fields = Form_Presenter::create_checkbox(
+			'myyoast_oauth_overrides_enabled',
+			\esc_html__( 'Override the MyYoast OAuth issuer, software statement and initial access token.', 'yoast-test-helper' ),
+			$enabled,
+		);
+
+		$select_options                        = self::PREDEFINED_ISSUERS;
+		$select_options['']                    = \__( '— pick an issuer —', 'yoast-test-helper' );
+		$select_options[ self::ISSUER_CUSTOM ] = \__( 'Custom URL…', 'yoast-test-helper' );
+
+		$dropdown_value = ( $custom_issuer !== '' ) ? self::ISSUER_CUSTOM : $selected;
+		$fields        .= Form_Presenter::create_select(
+			'myyoast_oauth_issuer',
+			\esc_html__( 'Issuer:', 'yoast-test-helper' ),
+			$select_options,
+			$dropdown_value,
+		);
+
+		$custom_row_hidden = ( $dropdown_value === self::ISSUER_CUSTOM ) ? '' : ' hidden';
+		$fields           .= \sprintf(
+			'<div id="myyoast_oauth_custom_issuer_row"%1$s><label for="myyoast_oauth_custom_issuer">%2$s</label> <input type="url" size="30" id="myyoast_oauth_custom_issuer" name="myyoast_oauth_custom_issuer" value="%3$s" placeholder="https://my.yoast.test"/><br/></div>',
+			$custom_row_hidden,
+			\esc_html__( 'Custom issuer URL:', 'yoast-test-helper' ),
+			\esc_attr( $custom_issuer ),
+		);
+
+		$fields .= \sprintf(
+			'<label for="myyoast_oauth_pat">%1$s</label> <input type="password" size="40" id="myyoast_oauth_pat" name="myyoast_oauth_pat" value="" autocomplete="off" placeholder="myp_••••••••"/> <em>%2$s</em><br/>',
+			\esc_html__( 'MyYoast PAT:', 'yoast-test-helper' ),
+			\esc_html__( '(blank = keep stored value)', 'yoast-test-helper' ),
+		);
+
+		$output = Form_Presenter::get_html(
+			\__( 'MyYoast OAuth overrides', 'yoast-test-helper' ),
+			'yoast_test_myyoast_oauth_save',
+			$fields,
+		);
+
+		$output .= '<hr/>';
+		$output .= $this->render_status( $active_issuer, $credentials );
+
+		$output .= '<div class="wpseo_test_actions">';
+		$output .= $this->render_action_form(
+			'yoast_test_myyoast_oauth_fetch',
+			\esc_html__( 'Fetch credentials', 'yoast-test-helper' ),
+			( $active_issuer === '' || ! $has_pat ),
+			false,
+		);
+		$output .= '<p><em>' . \esc_html__( 'Each environment requires its own credentials. Switch the issuer above to generate or fetch a new set.', 'yoast-test-helper' ) . '</em></p>';
+
+		$clear_prompt = \__(
+			'Clear all MyYoast OAuth state?
+
+This wipes the local OAuth client state for the active issuer:
+
+• The plugin will deregister with MyYoast (best-effort), then forget the registered client.
+• All site-level and user-level access tokens will be deleted. Every WordPress user that connected to MyYoast must sign in again.
+• Both key pairs (registration JWT signing + DPoP) will be rotated.
+• OIDC discovery, JWKS and DPoP nonce caches will be cleared.
+• PATs stored in the test helper itself are kept.',
+			'yoast-test-helper',
+		);
+
+		$output .= '</div>';
+
+		$output .= '<hr/>';
+
+		$output .= $this->render_action_form(
+			'yoast_test_myyoast_oauth_clear_client',
+			\esc_html__( 'Clear OAuth state', 'yoast-test-helper' ),
+			false,
+			true,
+			$clear_prompt,
+		);
+
+		$output .= $this->render_custom_issuer_toggle_script();
+
+		return $output;
+	}
+
+	/**
+	 * Inline script that toggles the custom issuer URL row based on the dropdown value.
+	 * The claims dialog opens/closes declaratively via `command`/`commandfor`; the clear
+	 * confirmation uses a plain `window.confirm()` on form submit (see render_action_form).
+	 *
+	 * @return string The script tag HTML.
+	 */
+	private function render_custom_issuer_toggle_script() {
+		return <<<'HTML'
+<script>
+( function() {
+	const select = document.getElementById( "myyoast_oauth_issuer" );
+	const row    = document.getElementById( "myyoast_oauth_custom_issuer_row" );
+	if ( ! select || ! row ) {
+		return;
+	}
+	var sync = function() {
+		row.toggleAttribute( "hidden", select.value !== "custom" );
+	};
+	select.addEventListener( "change", sync );
+	sync();
+} )();
+</script>
+HTML;
+	}
+
+	/**
+	 * Renders an extra single-button form (Fetch / Clear) without its own `<h2>` heading.
+	 *
+	 * @param string $action          The admin-post action name (also used as the nonce field).
+	 * @param string $label           The button label.
+	 * @param bool   $disabled        Whether the button should be disabled.
+	 * @param bool   $is_link         Whether to render a destructive red link instead of a button.
+	 * @param string $confirm_message Optional message for a window.confirm() guard. Empty string = no prompt.
+	 *
+	 * @return string The HTML.
+	 */
+	private function render_action_form( $action, $label, $disabled, $is_link, $confirm_message = '' ) {
+		$attrs       = ( $disabled ) ? ' disabled="disabled"' : '';
+		$button_attr = ( $is_link ) ? 'class="button-link button-link-delete"' : 'class="button"';
+		$onsubmit    = ( $confirm_message === '' ) ? '' : ' onsubmit="return confirm(' . \esc_attr( WPSEO_Utils::format_json_encode( $confirm_message ) ) . ')"';
+
+		$output  = '<form action="' . \esc_url( \admin_url( 'admin-post.php' ) ) . '" method="POST"' . $onsubmit . '>';
+		$output .= \str_replace( 'id="_wpnonce"', '', \wp_nonce_field( $action, '_wpnonce', true, false ) );
+		$output .= '<input type="hidden" name="action" value="' . \esc_attr( $action ) . '">';
+		$output .= \sprintf(
+			'<button id="%1$s_button" %2$s%3$s type="submit">%4$s</button>',
+			\esc_attr( $action ),
+			$button_attr,
+			$attrs,
+			$label,
+		);
+		$output .= '</form>';
+
+		return $output;
+	}
+
+	/**
+	 * Renders a compact status block summarising the active issuer and any stored credentials.
+	 *
+	 * @param string                               $active_issuer The currently active issuer URL.
+	 * @param array<string, string|int|float|bool> $credentials   The stored credentials for the active issuer.
+	 *
+	 * @return string The HTML.
+	 */
+	private function render_status( $active_issuer, array $credentials ) {
+		$issuer_label      = ( $active_issuer === '' ) ? \esc_html__( '(none configured)', 'yoast-test-helper' ) : \esc_html( $active_issuer );
+		$has_credentials   = ( ! empty( $credentials['software_statement'] ) && ! empty( $credentials['initial_access_token'] ) );
+		$credentials_label = ( $has_credentials ) ? \esc_html__( 'yes', 'yoast-test-helper' ) : \esc_html__( 'no', 'yoast-test-helper' );
+
+		$output  = '<p><strong>' . \esc_html__( 'Active issuer:', 'yoast-test-helper' ) . '</strong> ' . $issuer_label . '<br/>';
+		$output .= '<strong>' . \esc_html__( 'Stored credentials:', 'yoast-test-helper' ) . '</strong> ' . $credentials_label . '</p>';
+
+		if ( ! $has_credentials ) {
+			return $output;
+		}
+
+		$claims = $this->decode_software_statement_claims( (string) $credentials['software_statement'] );
+		if ( $claims === [] ) {
+			return $output;
+		}
+
+		$rows = '';
+		foreach ( [ 'software_id', 'software_version', 'iss', 'aud', 'iat', 'exp', 'jti' ] as $claim ) {
+			if ( ! isset( $claims[ $claim ] ) ) {
+				continue;
+			}
+			$rows .= '<tr><td><strong>' . \esc_html( $claim ) . '</strong></td>';
+			$rows .= '<td><code>' . \esc_html( $this->stringify_claim( $claims[ $claim ] ) ) . '</code></td></tr>';
+		}
+
+		$output .= '<p><button type="button" class="button-link" command="show-modal" commandfor="myyoast_oauth_claims_dialog">' . \esc_html__( 'View decoded software statement claims', 'yoast-test-helper' ) . '</button></p>';
+
+		$output .= '<dialog id="myyoast_oauth_claims_dialog" class="wpseo_test_dialog">';
+		$output .= '<header class="wpseo_test_dialog_header">';
+		$output .= '<h3>' . \esc_html__( 'Decoded software statement claims', 'yoast-test-helper' ) . '</h3>';
+		$output .= '<button type="button" class="wpseo_test_dialog_close" command="close" commandfor="myyoast_oauth_claims_dialog" aria-label="' . \esc_attr__( 'Close', 'yoast-test-helper' ) . '">&times;</button>';
+		$output .= '</header>';
+		$output .= '<table>' . $rows . '</table>';
+		$output .= '</dialog>';
+
+		return $output;
+	}
+
+	/**
+	 * Handles the settings form submit.
+	 *
+	 * @return void
+	 */
+	public function handle_save() {
+		if ( \check_admin_referer( 'yoast_test_myyoast_oauth_save' ) === false ) {
+			$this->redirect();
+
+			return;
+		}
+
+		$this->option->set( 'myyoast_oauth_overrides_enabled', isset( $_POST['myyoast_oauth_overrides_enabled'] ) );
+
+		$selected = '';
+		if ( isset( $_POST['myyoast_oauth_issuer'] ) && \is_string( $_POST['myyoast_oauth_issuer'] ) ) {
+			$selected = \sanitize_text_field( \wp_unslash( $_POST['myyoast_oauth_issuer'] ) );
+		}
+
+		$custom = '';
+		if ( isset( $_POST['myyoast_oauth_custom_issuer'] ) && \is_string( $_POST['myyoast_oauth_custom_issuer'] ) ) {
+			$custom = \esc_url_raw( \wp_unslash( $_POST['myyoast_oauth_custom_issuer'] ) );
+		}
+
+		$issuer = $this->resolve_issuer( $selected, $custom );
+		$this->option->set( 'myyoast_oauth_active_issuer', $issuer );
+		$this->option->set( 'myyoast_oauth_custom_issuer', $custom );
+
+		if ( isset( $_POST['myyoast_oauth_pat'] ) && \is_string( $_POST['myyoast_oauth_pat'] ) ) {
+			$pat = \trim( \sanitize_text_field( \wp_unslash( $_POST['myyoast_oauth_pat'] ) ) );
+			if ( $pat !== '' && $issuer !== '' ) {
+				$this->store_credential_field( $issuer, 'pat', $pat );
+			}
+		}
+
+		$this->redirect();
+	}
+
+	/**
+	 * Handles the fetch form submit.
+	 *
+	 * @return void
+	 */
+	public function handle_fetch() {
+		if ( \check_admin_referer( 'yoast_test_myyoast_oauth_fetch' ) === false ) {
+			$this->redirect();
+
+			return;
+		}
+
+		$issuer = $this->get_active_issuer();
+		if ( $issuer === '' ) {
+			$this->add_notification( \__( 'Pick an issuer and save before fetching credentials.', 'yoast-test-helper' ), 'error' );
+			$this->redirect();
+
+			return;
+		}
+
+		$credentials = $this->get_active_credentials();
+		$pat         = isset( $credentials['pat'] ) ? (string) $credentials['pat'] : '';
+		if ( $pat === '' ) {
+			$this->add_notification( \__( 'No PAT stored for the active issuer. Paste one in the settings form and save first.', 'yoast-test-helper' ), 'error' );
+			$this->redirect();
+
+			return;
+		}
+
+		$response = $this->request_credentials( $issuer, $pat );
+		if ( \is_wp_error( $response ) ) {
+			$this->add_notification(
+				\sprintf(
+					/* translators: %s expands to the WordPress error message. */
+					\esc_html__( 'Could not reach the credentials endpoint: %s', 'yoast-test-helper' ),
+					$response->get_error_message(),
+				),
+				'error',
+			);
+			$this->redirect();
+
+			return;
+		}
+
+		$status = (int) \wp_remote_retrieve_response_code( $response );
+		if ( $status < 200 || $status >= 300 ) {
+			$this->add_notification(
+				\sprintf(
+					/* translators: 1: HTTP status code, 2: response body. */
+					\esc_html__( 'Credentials endpoint returned HTTP %1$d. Body: %2$s', 'yoast-test-helper' ),
+					$status,
+					\esc_html( (string) \wp_remote_retrieve_body( $response ) ),
+				),
+				'error',
+			);
+			$this->redirect();
+
+			return;
+		}
+
+		$body    = (string) \wp_remote_retrieve_body( $response );
+		$decoded = \json_decode( $body, true );
+		if ( ! \is_array( $decoded ) ) {
+			$this->add_notification( \__( 'Credentials endpoint returned a response that is not valid JSON.', 'yoast-test-helper' ), 'error' );
+			$this->redirect();
+
+			return;
+		}
+
+		$software_statement   = '';
+		$initial_access_token = '';
+		if ( isset( $decoded['softwareStatement'] ) && \is_string( $decoded['softwareStatement'] ) ) {
+			$software_statement = $decoded['softwareStatement'];
+		}
+		if ( isset( $decoded['initialAccessToken'] ) && \is_string( $decoded['initialAccessToken'] ) ) {
+			$initial_access_token = $decoded['initialAccessToken'];
+		}
+
+		if ( $software_statement === '' || $initial_access_token === '' ) {
+			$this->add_notification( \__( 'Credentials endpoint response is missing softwareStatement or initialAccessToken.', 'yoast-test-helper' ), 'error' );
+			$this->redirect();
+
+			return;
+		}
+
+		$this->store_credential_field( $issuer, 'software_statement', $software_statement );
+		$this->store_credential_field( $issuer, 'initial_access_token', $initial_access_token );
+		$this->store_credential_field( $issuer, 'fetched_at', \time() );
+
+		$this->add_notification(
+			\sprintf(
+				/* translators: %s expands to the issuer URL. */
+				\esc_html__( 'Stored a fresh software statement and initial access token for %s.', 'yoast-test-helper' ),
+				\esc_html( $issuer ),
+			),
+			'success',
+		);
+		$this->redirect();
+	}
+
+	/**
+	 * Handles the clear-state form submit.
+	 *
+	 * @return void
+	 */
+	public function handle_clear_client() {
+		if ( \check_admin_referer( 'yoast_test_myyoast_oauth_clear_client' ) === false ) {
+			$this->redirect();
+
+			return;
+		}
+
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.DynamicHooknameFound -- Foreign hook owned by the wordpress-seo plugin.
+		\do_action( self::CLEAR_STATE_ACTION );
+
+		$this->add_notification( \__( 'Fired wpseo_myyoast_clear_client_state. Local OAuth state in Yoast SEO has been wiped (if Yoast SEO is active and the MyYoast connection feature flag is on).', 'yoast-test-helper' ), 'success' );
+		$this->redirect();
+	}
+
+	/**
+	 * Sends the SS+IAT request to the configured issuer.
+	 *
+	 * @param string $issuer The issuer URL.
+	 * @param string $pat    The bearer token to authenticate with.
+	 *
+	 * @return array<string, string|int|array<string, string>|object>|WP_Error The wp_remote_post response.
+	 *                        The array shape is the standard WordPress HTTP response; we hand it straight
+	 *                        to wp_remote_retrieve_*() helpers and never poke into it directly.
+	 */
+	private function request_credentials( $issuer, $pat ) {
+		$body                    = self::STATEMENT_CLAIMS;
+		$body['softwareVersion'] = ( \defined( 'WPSEO_VERSION' ) ) ? \WPSEO_VERSION : 'dev';
+
+		return \wp_remote_post(
+			\rtrim( $issuer, '/' ) . self::CREDENTIALS_PATH,
+			[
+				'timeout' => 30,
+				'headers' => [
+					'Authorization' => 'Bearer ' . $pat,
+					'Content-Type'  => 'application/json',
+					'Accept'        => 'application/json',
+				],
+				'body'    => WPSEO_Utils::format_json_encode( $body ),
+			],
+		);
+	}
+
+	/**
+	 * Decodes the payload segment of an unverified JWT into an associative array.
+	 * The signature is not checked — this is for display only.
+	 *
+	 * @param string $jwt The JWT.
+	 *
+	 * @return array<string, string|int|float|bool|array<int|string, string|int|float|bool>> The decoded claims, or an empty array on failure.
+	 */
+	private function decode_software_statement_claims( $jwt ) {
+		$segments = \explode( '.', $jwt );
+		if ( \count( $segments ) !== 3 ) {
+			return [];
+		}
+
+		$padded  = \strtr( $segments[1], '-_', '+/' );
+		$padded .= \str_repeat( '=', ( ( 4 - ( \strlen( $padded ) % 4 ) ) % 4 ) );
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decoding a JWT segment, not obfuscation.
+		$json = \base64_decode( $padded, true );
+		if ( $json === false ) {
+			return [];
+		}
+
+		$claims = \json_decode( $json, true );
+
+		return \is_array( $claims ) ? $claims : [];
+	}
+
+	/**
+	 * Coerces a JWT claim value into a short displayable string.
+	 *
+	 * @param string|int|float|bool|array<int|string, string|int|float|bool>|null $value The claim value.
+	 *
+	 * @return string The string representation.
+	 */
+	private function stringify_claim( $value ) {
+		if ( \is_scalar( $value ) ) {
+			return (string) $value;
+		}
+
+		return (string) WPSEO_Utils::format_json_encode( $value );
+	}
+
+	/**
+	 * Returns the active issuer URL from option storage.
+	 *
+	 * @return string The active issuer URL, or '' when none is configured.
+	 */
+	private function get_active_issuer() {
+		$value = $this->option->get( 'myyoast_oauth_active_issuer' );
+
+		return \is_string( $value ) ? $value : '';
+	}
+
+	/**
+	 * Returns the credential record stored for the active issuer.
+	 *
+	 * @return array<string, string|int|float|bool> The credential record, or [] when none is stored.
+	 */
+	private function get_active_credentials() {
+		$issuer = $this->get_active_issuer();
+		if ( $issuer === '' ) {
+			return [];
+		}
+
+		$store = $this->option->get( 'myyoast_oauth_credentials' );
+		if ( ! \is_array( $store ) || ! isset( $store[ $issuer ] ) || ! \is_array( $store[ $issuer ] ) ) {
+			return [];
+		}
+
+		return $store[ $issuer ];
+	}
+
+	/**
+	 * Returns whether a PAT is stored for the active issuer.
+	 *
+	 * @return bool True when a non-empty PAT is stored.
+	 */
+	private function has_active_pat() {
+		$credentials = $this->get_active_credentials();
+
+		return ! empty( $credentials['pat'] );
+	}
+
+	/**
+	 * Persists a single credential field for the given issuer, leaving other fields untouched.
+	 *
+	 * @param string                $issuer The issuer URL.
+	 * @param string                $field  The credential field name.
+	 * @param string|int|float|bool $value  The credential value.
+	 *
+	 * @return void
+	 */
+	private function store_credential_field( $issuer, $field, $value ) {
+		$store = $this->option->get( 'myyoast_oauth_credentials' );
+		if ( ! \is_array( $store ) ) {
+			$store = [];
+		}
+
+		$record           = ( isset( $store[ $issuer ] ) && \is_array( $store[ $issuer ] ) ) ? $store[ $issuer ] : [];
+		$record[ $field ] = $value;
+		$store[ $issuer ] = $record;
+
+		$this->option->set( 'myyoast_oauth_credentials', $store );
+	}
+
+	/**
+	 * Resolves the effective issuer URL from the submitted dropdown + custom values.
+	 *
+	 * @param string $selected The dropdown value (predefined URL, '', or 'custom').
+	 * @param string $custom   The custom URL value.
+	 *
+	 * @return string The effective issuer URL, or '' when nothing was selected.
+	 */
+	private function resolve_issuer( $selected, $custom ) {
+		if ( $selected === self::ISSUER_CUSTOM ) {
+			return $custom;
+		}
+
+		if ( isset( self::PREDEFINED_ISSUERS[ $selected ] ) ) {
+			return $selected;
+		}
+
+		return '';
+	}
+
+	/**
+	 * Queues a notification on the test helper admin page.
+	 *
+	 * @param string $message The notification message.
+	 * @param string $type    The notification type (info, success, error).
+	 *
+	 * @return void
+	 */
+	private function add_notification( $message, $type = 'info' ) {
+		\do_action( 'Yoast\WP\Test_Helper\notification', new Notification( $message, $type ) );
+	}
+
+	/**
+	 * Redirects back to the test helper admin page.
+	 *
+	 * @return void
+	 */
+	private function redirect() {
+		\wp_safe_redirect( \self_admin_url( 'tools.php?page=' . \apply_filters( 'Yoast\WP\Test_Helper\admin_page', '' ) ) );
+	}
+}

--- a/src/myyoast-oauth-overrides.php
+++ b/src/myyoast-oauth-overrides.php
@@ -6,10 +6,11 @@ use WP_Error;
 use WPSEO_Utils;
 
 /**
- * Lets a developer point the Yoast SEO MyYoast OAuth client at a non-production
- * issuer (staging, local) by overriding the `wpseo_myyoast_issuer_url`,
- * `wpseo_myyoast_software_statement`, and `wpseo_myyoast_initial_access_token`
- * filters.
+ * Configures the Yoast SEO MyYoast OAuth client for the active environment.
+ *
+ * The active environment is owned by {@see Domain_Dropdown}; this integration
+ * just configures the OAuth credentials (PAT, software statement, initial
+ * access token) that go with whichever environment that dropdown is set to.
  *
  * Instead of taking a raw software statement and initial access token by hand,
  * the developer enters a MyYoast Personal Access Token (PAT) for the chosen
@@ -18,8 +19,11 @@ use WPSEO_Utils;
  * `update-myyoast-credentials` Grunt task uses at artifact-build time).
  *
  * PATs and credential pairs are persisted per issuer URL so a developer can
- * keep credentials for multiple environments side-by-side and switch without
- * re-pasting.
+ * keep credentials for multiple environments side-by-side and switch by
+ * changing the Domain Dropdown.
+ *
+ * The three `wpseo_myyoast_*` filters fire iff the active environment is
+ * non-production AND credentials are stored for it.
  */
 class MyYoast_OAuth_Overrides implements Integration {
 
@@ -56,28 +60,6 @@ class MyYoast_OAuth_Overrides implements Integration {
 	];
 
 	/**
-	 * Sentinel value selected from the issuer dropdown to mean "use the custom URL".
-	 *
-	 * @var string
-	 */
-	private const ISSUER_CUSTOM = 'custom';
-
-	/**
-	 * Predefined issuer URLs, mirroring the Domain_Dropdown set.
-	 *
-	 * @var array<string, string>
-	 */
-	private const PREDEFINED_ISSUERS = [
-		'https://my.yoast.com'                  => 'live',
-		'https://staging.yoast.com'             => 'staging',
-		'https://staging-plugins.yoast.com'     => 'staging-plugins',
-		'https://staging-platform.yoast.com'    => 'staging-platform',
-		'https://staging-4-my.yoast.com'        => 'staging-4',
-		'https://staging-5-my.yoast.com'        => 'staging-5',
-		'http://my.yoast.test'                  => 'local',
-	];
-
-	/**
 	 * Holds our option instance.
 	 *
 	 * @var Option
@@ -85,12 +67,21 @@ class MyYoast_OAuth_Overrides implements Integration {
 	private $option;
 
 	/**
+	 * Source of truth for the active MyYoast environment.
+	 *
+	 * @var Domain_Dropdown
+	 */
+	private $domain_dropdown;
+
+	/**
 	 * Class constructor.
 	 *
-	 * @param Option $option Our option array.
+	 * @param Option          $option          Our option array.
+	 * @param Domain_Dropdown $domain_dropdown The card that owns the active-environment selection.
 	 */
-	public function __construct( Option $option ) {
-		$this->option = $option;
+	public function __construct( Option $option, Domain_Dropdown $domain_dropdown ) {
+		$this->option          = $option;
+		$this->domain_dropdown = $domain_dropdown;
 	}
 
 	/**
@@ -99,7 +90,7 @@ class MyYoast_OAuth_Overrides implements Integration {
 	 * @return void
 	 */
 	public function add_hooks() {
-		if ( $this->option->get( 'myyoast_oauth_overrides_enabled' ) ) {
+		if ( $this->should_apply_overrides() ) {
 			\add_filter( 'wpseo_myyoast_issuer_url', [ $this, 'filter_issuer_url' ] );
 			\add_filter( 'wpseo_myyoast_software_statement', [ $this, 'filter_software_statement' ] );
 			\add_filter( 'wpseo_myyoast_initial_access_token', [ $this, 'filter_initial_access_token' ] );
@@ -113,17 +104,10 @@ class MyYoast_OAuth_Overrides implements Integration {
 	/**
 	 * Filters the MyYoast issuer URL.
 	 *
-	 * @param string $value The default issuer URL.
-	 *
-	 * @return string The active issuer URL when one is configured, the original value otherwise.
+	 * @return string The active environment URL.
 	 */
-	public function filter_issuer_url( $value ) {
-		$issuer = $this->get_active_issuer();
-		if ( $issuer === '' ) {
-			return $value;
-		}
-
-		return $issuer;
+	public function filter_issuer_url() {
+		return $this->get_active_issuer();
 	}
 
 	/**
@@ -164,44 +148,24 @@ class MyYoast_OAuth_Overrides implements Integration {
 	 * @return string The HTML to use to render the controls.
 	 */
 	public function get_controls() {
-		$enabled       = (bool) $this->option->get( 'myyoast_oauth_overrides_enabled' );
 		$active_issuer = $this->get_active_issuer();
-		$is_predefined = ( $active_issuer !== '' && isset( self::PREDEFINED_ISSUERS[ $active_issuer ] ) );
-		$selected      = ( $is_predefined ) ? $active_issuer : '';
-		$custom_issuer = ( $active_issuer !== '' && ! $is_predefined ) ? $active_issuer : '';
+		$is_production = $this->is_production( $active_issuer );
 		$has_pat       = $this->has_active_pat();
 		$credentials   = $this->get_active_credentials();
 
-		$fields = Form_Presenter::create_checkbox(
-			'myyoast_oauth_overrides_enabled',
-			\esc_html__( 'Override the MyYoast OAuth issuer, software statement and initial access token.', 'yoast-test-helper' ),
-			$enabled,
-		);
+		$fields = '<p>' . \sprintf(
+			/* translators: %s expands to the active issuer URL. */
+			\esc_html__( 'Configures the OAuth credentials for the environment selected in the Domain Dropdown card: %s.', 'yoast-test-helper' ),
+			'<code>' . \esc_html( $active_issuer ) . '</code>',
+		) . '</p>';
 
-		$select_options                        = self::PREDEFINED_ISSUERS;
-		$select_options['']                    = \__( '— pick an issuer —', 'yoast-test-helper' );
-		$select_options[ self::ISSUER_CUSTOM ] = \__( 'Custom URL…', 'yoast-test-helper' );
+		if ( $is_production ) {
+			$fields .= '<p><em>' . \esc_html__( 'No overrides apply on production — Yoast SEO ships with valid baked-in credentials. Switch the Domain Dropdown to a non-production environment to configure credentials here.', 'yoast-test-helper' ) . '</em></p>';
+		}
 
-		$dropdown_value = ( $custom_issuer !== '' ) ? self::ISSUER_CUSTOM : $selected;
-		$fields        .= Form_Presenter::create_select(
-			'myyoast_oauth_issuer',
-			\esc_html__( 'Issuer:', 'yoast-test-helper' ),
-			$select_options,
-			$dropdown_value,
-		);
-
-		$custom_row_hidden = ( $dropdown_value === self::ISSUER_CUSTOM ) ? '' : ' hidden';
-		$fields           .= \sprintf(
-			'<div id="myyoast_oauth_custom_issuer_row"%1$s><label for="myyoast_oauth_custom_issuer">%2$s</label> <input type="url" size="30" id="myyoast_oauth_custom_issuer" name="myyoast_oauth_custom_issuer" value="%3$s" placeholder="https://my.yoast.test"/><br/></div>',
-			$custom_row_hidden,
-			\esc_html__( 'Custom issuer URL:', 'yoast-test-helper' ),
-			\esc_attr( $custom_issuer ),
-		);
-
-		$fields .= \sprintf(
-			'<label for="myyoast_oauth_pat">%1$s</label> <input type="password" size="40" id="myyoast_oauth_pat" name="myyoast_oauth_pat" value="" autocomplete="off" placeholder="myp_••••••••"/> <em>%2$s</em><br/>',
-			\esc_html__( 'MyYoast PAT:', 'yoast-test-helper' ),
-			\esc_html__( '(blank = keep stored value)', 'yoast-test-helper' ),
+		$fields         .= \sprintf(
+			'<label for="myyoast_oauth_pat">%1$s</label> <input type="password" size="40" id="myyoast_oauth_pat" name="myyoast_oauth_pat" value="" autocomplete="off" placeholder="myp_••••••••"/><br/>',
+			\esc_html__( 'MyYoast PAT for this environment:', 'yoast-test-helper' ),
 		);
 
 		$output = Form_Presenter::get_html(
@@ -217,10 +181,10 @@ class MyYoast_OAuth_Overrides implements Integration {
 		$output .= $this->render_action_form(
 			'yoast_test_myyoast_oauth_fetch',
 			\esc_html__( 'Fetch credentials', 'yoast-test-helper' ),
-			( $active_issuer === '' || ! $has_pat ),
+			( $is_production || ! $has_pat ),
 			false,
 		);
-		$output .= '<p><em>' . \esc_html__( 'Each environment requires its own credentials. Switch the issuer above to generate or fetch a new set.', 'yoast-test-helper' ) . '</em></p>';
+		$output .= '</div>';
 
 		$clear_prompt = \__(
 			'Clear all MyYoast OAuth state?
@@ -235,10 +199,7 @@ This wipes the local OAuth client state for the active issuer:
 			'yoast-test-helper',
 		);
 
-		$output .= '</div>';
-
 		$output .= '<hr/>';
-
 		$output .= $this->render_action_form(
 			'yoast_test_myyoast_oauth_clear_client',
 			\esc_html__( 'Clear OAuth state', 'yoast-test-helper' ),
@@ -247,35 +208,7 @@ This wipes the local OAuth client state for the active issuer:
 			$clear_prompt,
 		);
 
-		$output .= $this->render_custom_issuer_toggle_script();
-
 		return $output;
-	}
-
-	/**
-	 * Inline script that toggles the custom issuer URL row based on the dropdown value.
-	 * The claims dialog opens/closes declaratively via `command`/`commandfor`; the clear
-	 * confirmation uses a plain `window.confirm()` on form submit (see render_action_form).
-	 *
-	 * @return string The script tag HTML.
-	 */
-	private function render_custom_issuer_toggle_script() {
-		return <<<'HTML'
-<script>
-( function() {
-	const select = document.getElementById( "myyoast_oauth_issuer" );
-	const row    = document.getElementById( "myyoast_oauth_custom_issuer_row" );
-	if ( ! select || ! row ) {
-		return;
-	}
-	var sync = function() {
-		row.toggleAttribute( "hidden", select.value !== "custom" );
-	};
-	select.addEventListener( "change", sync );
-	sync();
-} )();
-</script>
-HTML;
 	}
 
 	/**
@@ -318,11 +251,10 @@ HTML;
 	 * @return string The HTML.
 	 */
 	private function render_status( $active_issuer, array $credentials ) {
-		$issuer_label      = ( $active_issuer === '' ) ? \esc_html__( '(none configured)', 'yoast-test-helper' ) : \esc_html( $active_issuer );
 		$has_credentials   = ( ! empty( $credentials['software_statement'] ) && ! empty( $credentials['initial_access_token'] ) );
 		$credentials_label = ( $has_credentials ) ? \esc_html__( 'yes', 'yoast-test-helper' ) : \esc_html__( 'no', 'yoast-test-helper' );
 
-		$output  = '<p><strong>' . \esc_html__( 'Active issuer:', 'yoast-test-helper' ) . '</strong> ' . $issuer_label . '<br/>';
+		$output  = '<p><strong>' . \esc_html__( 'Active issuer:', 'yoast-test-helper' ) . '</strong> ' . \esc_html( $active_issuer ) . '<br/>';
 		$output .= '<strong>' . \esc_html__( 'Stored credentials:', 'yoast-test-helper' ) . '</strong> ' . $credentials_label . '</p>';
 
 		if ( ! $has_credentials ) {
@@ -357,7 +289,7 @@ HTML;
 	}
 
 	/**
-	 * Handles the settings form submit.
+	 * Handles the settings form submit. Stores the PAT for the active environment.
 	 *
 	 * @return void
 	 */
@@ -368,28 +300,15 @@ HTML;
 			return;
 		}
 
-		$this->option->set( 'myyoast_oauth_overrides_enabled', isset( $_POST['myyoast_oauth_overrides_enabled'] ) );
-
-		$selected = '';
-		if ( isset( $_POST['myyoast_oauth_issuer'] ) && \is_string( $_POST['myyoast_oauth_issuer'] ) ) {
-			$selected = \sanitize_text_field( \wp_unslash( $_POST['myyoast_oauth_issuer'] ) );
-		}
-
-		$custom = '';
-		if ( isset( $_POST['myyoast_oauth_custom_issuer'] ) && \is_string( $_POST['myyoast_oauth_custom_issuer'] ) ) {
-			$custom = \esc_url_raw( \wp_unslash( $_POST['myyoast_oauth_custom_issuer'] ) );
-		}
-
-		$issuer = $this->resolve_issuer( $selected, $custom );
-		$this->option->set( 'myyoast_oauth_active_issuer', $issuer );
-		$this->option->set( 'myyoast_oauth_custom_issuer', $custom );
-
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- Nonce is verified above.
 		if ( isset( $_POST['myyoast_oauth_pat'] ) && \is_string( $_POST['myyoast_oauth_pat'] ) ) {
-			$pat = \trim( \sanitize_text_field( \wp_unslash( $_POST['myyoast_oauth_pat'] ) ) );
-			if ( $pat !== '' && $issuer !== '' ) {
+			$pat    = \trim( \sanitize_text_field( \wp_unslash( $_POST['myyoast_oauth_pat'] ) ) );
+			$issuer = $this->get_active_issuer();
+			if ( $pat !== '' && ! $this->is_production( $issuer ) ) {
 				$this->store_credential_field( $issuer, 'pat', $pat );
 			}
 		}
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
 
 		$this->redirect();
 	}
@@ -407,8 +326,8 @@ HTML;
 		}
 
 		$issuer = $this->get_active_issuer();
-		if ( $issuer === '' ) {
-			$this->add_notification( \__( 'Pick an issuer and save before fetching credentials.', 'yoast-test-helper' ), 'error' );
+		if ( $this->is_production( $issuer ) ) {
+			$this->add_notification( \__( 'The Domain Dropdown is on production. Switch to a staging or local environment before fetching credentials.', 'yoast-test-helper' ), 'error' );
 			$this->redirect();
 
 			return;
@@ -417,7 +336,7 @@ HTML;
 		$credentials = $this->get_active_credentials();
 		$pat         = isset( $credentials['pat'] ) ? (string) $credentials['pat'] : '';
 		if ( $pat === '' ) {
-			$this->add_notification( \__( 'No PAT stored for the active issuer. Paste one in the settings form and save first.', 'yoast-test-helper' ), 'error' );
+			$this->add_notification( \__( 'No PAT stored for the active environment. Paste one in the settings form and save first.', 'yoast-test-helper' ), 'error' );
 			$this->redirect();
 
 			return;
@@ -584,14 +503,42 @@ HTML;
 	}
 
 	/**
-	 * Returns the active issuer URL from option storage.
+	 * Returns the active issuer URL — i.e. the environment selected in Domain_Dropdown.
 	 *
-	 * @return string The active issuer URL, or '' when none is configured.
+	 * @return string The active issuer URL.
 	 */
 	private function get_active_issuer() {
-		$value = $this->option->get( 'myyoast_oauth_active_issuer' );
+		return $this->domain_dropdown->get_active_domain();
+	}
 
-		return \is_string( $value ) ? $value : '';
+	/**
+	 * Returns whether the given issuer is the production default. When true, the
+	 * OAuth filters do not fire — production credentials baked into Yoast SEO are
+	 * already correct.
+	 *
+	 * @param string $issuer The issuer URL.
+	 *
+	 * @return bool True when the issuer is the production default.
+	 */
+	private function is_production( $issuer ) {
+		return $issuer === Domain_Dropdown::DEFAULT_DOMAIN;
+	}
+
+	/**
+	 * Returns whether the OAuth filters should be registered: only when the active
+	 * environment is non-production AND credentials are stored for it.
+	 *
+	 * @return bool True when overrides should apply.
+	 */
+	private function should_apply_overrides() {
+		$issuer = $this->get_active_issuer();
+		if ( $this->is_production( $issuer ) ) {
+			return false;
+		}
+
+		$credentials = $this->get_active_credentials();
+
+		return ( ! empty( $credentials['software_statement'] ) && ! empty( $credentials['initial_access_token'] ) );
 	}
 
 	/**
@@ -601,9 +548,6 @@ HTML;
 	 */
 	private function get_active_credentials() {
 		$issuer = $this->get_active_issuer();
-		if ( $issuer === '' ) {
-			return [];
-		}
 
 		$store = $this->option->get( 'myyoast_oauth_credentials' );
 		if ( ! \is_array( $store ) || ! isset( $store[ $issuer ] ) || ! \is_array( $store[ $issuer ] ) ) {
@@ -644,26 +588,6 @@ HTML;
 		$store[ $issuer ] = $record;
 
 		$this->option->set( 'myyoast_oauth_credentials', $store );
-	}
-
-	/**
-	 * Resolves the effective issuer URL from the submitted dropdown + custom values.
-	 *
-	 * @param string $selected The dropdown value (predefined URL, '', or 'custom').
-	 * @param string $custom   The custom URL value.
-	 *
-	 * @return string The effective issuer URL, or '' when nothing was selected.
-	 */
-	private function resolve_issuer( $selected, $custom ) {
-		if ( $selected === self::ISSUER_CUSTOM ) {
-			return $custom;
-		}
-
-		if ( isset( self::PREDEFINED_ISSUERS[ $selected ] ) ) {
-			return $selected;
-		}
-
-		return '';
 	}
 
 	/**

--- a/src/plugin.php
+++ b/src/plugin.php
@@ -90,6 +90,7 @@ class Plugin implements Integration {
 		$this->integrations[] = new Taxonomies( $option );
 		$this->integrations[] = new Domain_Dropdown( $option );
 		$this->integrations[] = new Inline_Script( $option );
+		$this->integrations[] = new MyYoast_OAuth_Overrides( $option );
 		$this->integrations[] = new Admin_Debug_Info( $option );
 		$this->integrations[] = new Indexing_Reason_Integration();
 		$this->integrations[] = new Query_Monitor();

--- a/src/plugin.php
+++ b/src/plugin.php
@@ -88,9 +88,10 @@ class Plugin implements Integration {
 		$this->integrations[] = new Feature_Toggler( $option );
 		$this->integrations[] = new Post_Types( $option );
 		$this->integrations[] = new Taxonomies( $option );
-		$this->integrations[] = new Domain_Dropdown( $option );
+		$domain_dropdown      = new Domain_Dropdown( $option );
+		$this->integrations[] = $domain_dropdown;
 		$this->integrations[] = new Inline_Script( $option );
-		$this->integrations[] = new MyYoast_OAuth_Overrides( $option );
+		$this->integrations[] = new MyYoast_OAuth_Overrides( $option, $domain_dropdown );
 		$this->integrations[] = new Admin_Debug_Info( $option );
 		$this->integrations[] = new Indexing_Reason_Integration();
 		$this->integrations[] = new Query_Monitor();


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds a "MyYoast OAuth overrides" card that swaps Yoast SEO's MyYoast OAuth issuer + software statement + initial access token at runtime, fetched from `{issuer}/api/oauth/software-statements` using a developer-supplied PAT. Lets you point Yoast SEO at a non-production MyYoast environment (staging, local, custom URL) without editing `wp-config.php`.
* Updates the list of available domains in the Domain dropdown section.
* Adds a custom domain option in the Domain dropdown section.

<img width="672" height="714" alt="image" src="https://github.com/user-attachments/assets/817c5793-0897-49a2-ab7e-d3ed2d3a844c" />


## Relevant technical choices:

* **Domain Dropdown is the single source of truth for the active MyYoast environment.** It owns the dropdown set (live / staging / staging-plugins / staging-platform / staging-4 / staging-5 / local), a "Custom URL…" free-text option, and exposes `Domain_Dropdown::get_active_domain()`. The OAuth overrides card reads the active issuer from there instead of carrying its own dropdown — there is no longer any way to point the URL rewrite at staging while OAuth still uses production credentials.
* **Credentials are fetched, not pasted.** The developer enters a MyYoast PAT for the chosen issuer; the helper calls `{issuer}/api/oauth/software-statements` (the same endpoint the wordpress-seo `update-myyoast-credentials` Grunt task uses at build time) to mint a fresh software statement + initial access token pair.
* **PATs and credential pairs are persisted per issuer URL**, so a developer can keep credentials for multiple environments side-by-side and switch by changing the Domain Dropdown — no re-pasting.
* **The three `wpseo_myyoast_*` filters fire iff** the active environment is non-production AND credentials are stored for it. On production the integration is a no-op (Yoast SEO ships with valid baked-in credentials).
* **The PAT field is prefilled with its public prefix** (`<prefix>_<id>_********`) when one is stored — the same public prefix MyYoast surfaces in its own UI — so the developer can match what they see here against the PAT in their MyYoast account. On save, an unchanged masked value is treated as a no-op.
* **"Clear OAuth state" button** fires `wpseo_myyoast_clear_client_state` to trigger wordpress-seo's full cleanup path (deregister, drop tokens, rotate keys, clear discovery/JWKS/DPoP caches), guarded by a `window.confirm` explaining the consequences. PATs stored in the test helper itself are kept.
* **Admin_Page sets up a `ResizeObserver` per tile** so masonry re-flows when card content changes (e.g. the custom URL row toggling) without integrations having to know about masonry.
* **Code review fixes baked in:** strict nonce check on `Domain_Dropdown::handle_submit`, `esc_js`+`esc_attr` for the `onsubmit` confirm string, `esc_html` on `WP_Error::get_error_message()`, `exit()` after `wp_safe_redirect`, and the missing `$value` parameter on `filter_issuer_url`.

## Milestone

* [ ] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged

This PR can be acceptance tested by following these steps:

**Preconditions**
* Yoast SEO active with the MyYoast connection feature flag on.
* Admin access to a non-production MyYoast environment (e.g. staging) and a PAT for an account on it. PATs in MyYoast can be created from the account profile as of https://github.com/Yoast/Platform/pull/4444.

**Domain Dropdown changes**
* Tools → Yoast Test → "Domain Dropdown" card.
* Confirm the dropdown lists: live, staging, staging-plugins, staging-platform, staging-4, staging-5, local, and **Custom URL…**.
* Pick "Custom URL…" — confirm a free-text URL input appears below the dropdown.
* Enter `https://my.yoast.test` (or any URL), Save, reload the page. Confirm the dropdown is still on "Custom URL…" and the field still has the value.
* Switch back to a predefined entry, Save, reload — confirm the custom-URL row hides again.

**MyYoast OAuth overrides card — production no-op**
* Set Domain Dropdown to **live** and save.
* Open the "MyYoast OAuth overrides" card. Confirm:
  * The active issuer is shown as `https://my.yoast.com`.
  * A note explains that no overrides apply on production.
  * The "Fetch credentials" button is disabled.

**OAuth overrides card — staging happy path**
* Set Domain Dropdown to **staging** (or any non-production environment) and save.
* In "MyYoast OAuth overrides", paste a valid PAT for that environment and save.
* Reload — confirm the PAT field is prefilled with `<prefix>_<id>_********` (the public prefix from your MyYoast account). The asterisk half is a mask, not the real secret.
* Click **Fetch credentials**. Confirm a success notice naming the issuer.
* Reload — confirm "Stored credentials: yes" appears and a "View decoded software statement claims" button shows the expected `software_id`/`software_version`/`iss`/`aud`/`iat`/`jti` claims.

**OAuth overrides card — filters take effect**
* With staging credentials stored, trigger the MyYoast connect flow from Yoast SEO. Confirm the OAuth flow targets the staging environment (the issuer URL in the redirect should be staging, not `my.yoast.com`).
* Switch Domain Dropdown back to **live**. Confirm the connect flow now goes through production again — the override stops applying when the environment is production.

**Saving an unchanged PAT does not overwrite**
* With a stored PAT, open the form, do not edit the masked field, and Save. Reload — confirm the prefix on display has not changed.
* Now edit the field (paste a fresh PAT or change a single character), Save. Confirm the displayed prefix matches the new value.

**Per-environment credential isolation**
* Save a PAT and fetch credentials for staging.
* Switch to staging-platform, paste a different PAT, fetch credentials. Confirm both environments show "Stored credentials: yes" and that switching the Domain Dropdown swaps the displayed issuer + claims accordingly.

**Clear OAuth state**
* Connect Yoast SEO to MyYoast on staging.
* In the "MyYoast OAuth overrides" card, click **Clear OAuth state**. Confirm the `window.confirm` prompt lists what will be wiped.
* Confirm the dialog. Confirm a success notice appears, and that Yoast SEO's MyYoast page now shows you as disconnected. The PAT stored in the test helper should still be present.

**Error paths**
* In the OAuth overrides card on a non-production environment, save an invalid PAT (e.g. `myp_invalid_invalid`). Click Fetch credentials.
* Confirm an error notice is shown that includes the HTTP status and response body — and that no stale credentials get stored.
* Temporarily change the custom URL to something unreachable (e.g. `https://my.yoast.test.invalid`), save, click Fetch credentials. Confirm an error notice with the WordPress HTTP error message is shown.

**Security regression checks**
* From a logged-in admin browser, post to `admin-post.php` with `action=yoast_seo_domain_dropdown` and a `myyoast_test_domain` field but **no** `_wpnonce` (e.g. via curl with the admin session cookie). Confirm the option is **not** updated. (The pre-fix behavior would have silently saved.)
* Same check for `yoast_test_myyoast_oauth_save`, `yoast_test_myyoast_oauth_fetch`, `yoast_test_myyoast_oauth_clear_client` — all three should reject requests without a valid nonce.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

Fixes yoast/reserved-tasks#1167