### PR TITLE
Add automated release pipeline (changelog, release, release-RC)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,15 @@
-## Summary
+## Changelog Entry
+
+<!--
+Apply exactly one `changelog:` label to this PR:
+* `changelog: enhancement` – new feature or improvement.
+* `changelog: bugfix` – fixes a bug.
+* `changelog: other` – anything user-facing that isn't an enhancement or bugfix.
+* `changelog: non-user-facing` – internal, infra, tests, deps; excluded from the changelog.
+
+The bullet(s) below are picked up by the automated changelog generator.
+Keep them user-facing and end each with a full stop.
+-->
 
 This PR can be summarized in the following changelog entry:
 

--- a/.github/scripts/generate-changelog.sh
+++ b/.github/scripts/generate-changelog.sh
@@ -1,0 +1,204 @@
+#!/bin/bash
+# Generates a changelog section in readme.txt from merged PRs since the latest tag on the current branch.
+#
+# The new section is inserted directly below the `== Changelog ==` header. If a section for the
+# requested version already exists, it is replaced (its existing release date is preserved when no
+# RELEASE_DATE env var is provided).
+#
+# Required environment variables:
+#   GH_TOKEN   - GitHub token for API access.
+#   VERSION    - Version number (e.g., 1.19).
+#
+# Optional environment variables:
+#   PREVIOUS_TAG  - Tag to compare from (defaults to latest non-RC release tag on the branch).
+#   RELEASE_DATE  - Release date in YYYY-MM-DD format (defaults to existing value in readme.txt, then calculated).
+#   README_FILE   - Path to readme.txt (defaults to readme.txt).
+
+set -euo pipefail
+
+VERSION="${VERSION:?VERSION is required}"
+README_FILE="${README_FILE:-readme.txt}"
+
+if [ ! -f "$README_FILE" ]; then
+	echo "::error::$README_FILE not found."
+	exit 1
+fi
+
+# If a section for the requested version already exists in readme.txt, capture its release date so we
+# can preserve it (unless RELEASE_DATE was explicitly set).
+EXISTING_RELEASE_DATE=""
+EXISTING_SECTION=$(awk -v v="= ${VERSION} =" '
+	$0 == v { flag = 1; next }
+	flag && /^= [0-9]/ { flag = 0 }
+	flag { print }
+' "$README_FILE")
+
+if [ -n "$EXISTING_SECTION" ]; then
+	EXISTING_RELEASE_DATE=$(echo "$EXISTING_SECTION" | grep -oP '(?<=Release date: ).*' | head -1 || true)
+fi
+
+# Resolve the release date.
+if [ -n "${RELEASE_DATE:-}" ]; then
+	: # Use provided value.
+elif [ -n "$EXISTING_RELEASE_DATE" ]; then
+	RELEASE_DATE="$EXISTING_RELEASE_DATE"
+else
+	# Same rules as duplicate-post's grunt task:
+	#   patch (x.y.z, z>0): today.
+	#   minor/major: next Tuesday ~2 weeks out.
+	#   beta: ~3 weeks out.
+	BASE_VERSION=$(echo "$VERSION" | cut -d'-' -f1)
+	PATCH=$(echo "$BASE_VERSION" | awk -F. '{ print ($3 != "" ? $3 : 0) }')
+	SUFFIX=$(echo "$VERSION" | grep -oP '(?<=-).*' || true)
+
+	if [ "$PATCH" -gt 0 ]; then
+		RELEASE_DATE=$(date +%Y-%m-%d)
+	else
+		DAYS_TO_ADD=14
+		if echo "$SUFFIX" | grep -qi "beta"; then
+			DAYS_TO_ADD=21
+		fi
+		DAY_OF_WEEK=$(date +%w)
+		OFFSET=$(( 2 + DAYS_TO_ADD - DAY_OF_WEEK ))
+		RELEASE_DATE=$(date -d "+${OFFSET} days" +%Y-%m-%d)
+	fi
+fi
+
+# Resolve the previous tag.
+if [ -z "${PREVIOUS_TAG:-}" ]; then
+	PREVIOUS_TAG=$(git tag --sort=-creatordate --merged HEAD | grep -E '^[0-9]+\.[0-9]+(\.[0-9]+)?$' | head -1 || echo "")
+fi
+
+if [ -z "$PREVIOUS_TAG" ]; then
+	echo "::error::No previous tag found on this branch."
+	exit 1
+fi
+
+echo "Generating changelog for version $VERSION since tag $PREVIOUS_TAG (release date: $RELEASE_DATE)"
+
+PR_NUMBERS=$(git log --grep='Merge pull request' "$PREVIOUS_TAG..HEAD" --oneline | grep -oP '#\K[0-9]+' || true)
+
+if [ -z "$PR_NUMBERS" ]; then
+	echo "::warning::No merged PRs found since $PREVIOUS_TAG"
+	exit 0
+fi
+
+ENHANCEMENTS=""
+BUGFIXES=""
+OTHER=""
+
+for PR_NUM in $PR_NUMBERS; do
+	echo "Processing PR #$PR_NUM..."
+
+	PR_JSON=$(gh pr view "$PR_NUM" --json labels,body 2>/dev/null || echo '{"labels":[],"body":""}')
+
+	LABEL=$(echo "$PR_JSON" | jq -r '[.labels[].name] | map(select(startswith("changelog:"))) | first // empty' | sed 's/^changelog: //')
+
+	if [ -z "$LABEL" ] || [ "$LABEL" = "non-user-facing" ] || [ "$LABEL" = "reverted" ]; then
+		echo "  Skipping (label: ${LABEL:-none})"
+		continue
+	fi
+
+	BODY=$(echo "$PR_JSON" | jq -r '.body // ""')
+
+	# Capture bullet lines between the "Changelog Entry" anchor and the next markdown heading.
+	ENTRIES=$(echo "$BODY" | sed -n '/[Cc]hangelog [Ee]ntry/,/^##/p' | grep '^\*' | grep -v '^\* *$' || true)
+
+	if [ -z "$ENTRIES" ]; then
+		echo "  No changelog entry found"
+		continue
+	fi
+
+	# Each entry on its own line, drop empties.
+	FILTERED=$(echo "$ENTRIES" | sed '/^\* *$/d')
+
+	case "$LABEL" in
+		enhancement) ENHANCEMENTS+="$FILTERED"$'\n' ;;
+		bugfix)      BUGFIXES+="$FILTERED"$'\n' ;;
+		other)       OTHER+="$FILTERED"$'\n' ;;
+		*)           echo "  Unknown label: $LABEL, treating as other"; OTHER+="$FILTERED"$'\n' ;;
+	esac
+done
+
+# Build the new section in readme.txt format.
+NEW_SECTION="= ${VERSION} =
+
+Release date: ${RELEASE_DATE}
+"
+
+if [ -n "$ENHANCEMENTS" ]; then
+	NEW_SECTION+="
+Enhancements:
+$(echo -n "$ENHANCEMENTS" | sed '/^$/d')
+"
+fi
+
+if [ -n "$BUGFIXES" ]; then
+	NEW_SECTION+="
+Bugfixes:
+$(echo -n "$BUGFIXES" | sed '/^$/d')
+"
+fi
+
+if [ -n "$OTHER" ]; then
+	NEW_SECTION+="
+Other:
+$(echo -n "$OTHER" | sed '/^$/d')
+"
+fi
+
+# Splice the new section into readme.txt. If a section for VERSION exists, replace it; otherwise
+# insert immediately after `== Changelog ==` (skipping any blank line that follows the header).
+TMP_FILE=$(mktemp)
+SECTION_FILE=$(mktemp)
+printf '%s\n' "$NEW_SECTION" > "$SECTION_FILE"
+
+awk -v version="$VERSION" -v section_file="$SECTION_FILE" '
+	BEGIN {
+		while ( (getline line < section_file) > 0 ) {
+			new_section = new_section line "\n"
+		}
+		close(section_file)
+		inserted = 0
+		in_old = 0
+	}
+	{
+		if ( !inserted && /^== Changelog ==/ ) {
+			print
+			# Print the new section straight after the header. If the next line is blank, swallow it
+			# so we do not end up with a double blank line.
+			if ( (getline next_line) > 0 ) {
+				if ( next_line != "" ) {
+					printf "\n%s", new_section
+					print next_line
+				} else {
+					printf "\n%s", new_section
+				}
+			} else {
+				printf "\n%s", new_section
+			}
+			inserted = 1
+			next
+		}
+
+		# If a section for the same version exists later in the file, swallow it (already replaced above).
+		if ( $0 == "= " version " =" ) {
+			in_old = 1
+			next
+		}
+		if ( in_old ) {
+			if ( /^= [0-9]/ ) {
+				in_old = 0
+				print
+			}
+			next
+		}
+
+		print
+	}
+' "$README_FILE" > "$TMP_FILE"
+
+mv "$TMP_FILE" "$README_FILE"
+rm -f "$SECTION_FILE"
+
+echo "Updated $README_FILE with section for $VERSION"

--- a/.github/scripts/generate-changelog.sh
+++ b/.github/scripts/generate-changelog.sh
@@ -79,8 +79,8 @@ echo "Generating changelog for version $VERSION since tag $PREVIOUS_TAG (release
 PR_NUMBERS=$(git log --grep='Merge pull request' "$PREVIOUS_TAG..HEAD" --oneline | grep -oP '#\K[0-9]+' || true)
 
 if [ -z "$PR_NUMBERS" ]; then
-	echo "::warning::No merged PRs found since $PREVIOUS_TAG"
-	exit 0
+	echo "::error::No merged PRs found since $PREVIOUS_TAG; refusing to write an empty changelog section. If this is intentional, edit readme.txt manually."
+	exit 1
 fi
 
 ENHANCEMENTS=""
@@ -101,8 +101,11 @@ for PR_NUM in $PR_NUMBERS; do
 
 	BODY=$(echo "$PR_JSON" | jq -r '.body // ""')
 
+	# Strip HTML comments first so the PR template's instructional `* changelog: …` bullets
+	# (which live inside <!-- ... -->) are not picked up as changelog entries.
 	# Capture bullet lines between the "Changelog Entry" anchor and the next markdown heading.
-	ENTRIES=$(echo "$BODY" | sed -n '/[Cc]hangelog [Ee]ntry/,/^##/p' | grep '^\*' | grep -v '^\* *$' || true)
+	ENTRIES=$(echo "$BODY" | awk 'BEGIN{c=0} /<!--/{c=1} !c{print} /-->/{c=0}' \
+		| sed -n '/[Cc]hangelog [Ee]ntry/,/^##/p' | grep '^\*' | grep -v '^\* *$' || true)
 
 	if [ -z "$ENTRIES" ]; then
 		echo "  No changelog entry found"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,9 +23,13 @@ name: Deploy
 
 on:
   # Trigger the workflow whenever a new tag is created.
+  # RC tags (e.g. 1.19-RC1) are excluded so they do not publish to the dist repo's main branch;
+  # RC builds are handled by the `Release RC` workflow.
   push:
     tags:
       - '**'
+      - '!*-RC*'
+      - '!*-rc*'
   # Allow manually triggering the workflow.
   workflow_dispatch:
 

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -34,9 +34,10 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Checkout code
+      - name: Checkout develop
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: develop
           fetch-depth: 0
 
       - name: Generate changelog

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -1,0 +1,74 @@
+name: Generate Changelog
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version number (e.g., 1.19)'
+        required: true
+        type: string
+      previous-tag:
+        description: 'Previous tag to compare from (defaults to latest release tag, excluding RC/beta)'
+        required: false
+        type: string
+      release-date:
+        description: 'Release date in YYYY-MM-DD format (defaults to today for patches, next Tuesday ~2 weeks out for minor/major)'
+        required: false
+        type: string
+
+# Ensure only one changelog generation runs at a time per branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  generate-changelog:
+    name: "Generate changelog and open PR"
+    runs-on: ubuntu-latest
+
+    # Don't run on forks.
+    if: github.repository_owner == 'Yoast'
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Generate changelog
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+          PREVIOUS_TAG: ${{ inputs.previous-tag }}
+          RELEASE_DATE: ${{ inputs.release-date }}
+        run: bash .github/scripts/generate-changelog.sh
+
+      - name: Show readme.txt changelog section
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          awk -v v="= ${VERSION} =" '
+            $0 == v { flag = 1 }
+            flag { print }
+            flag && /^= [0-9]/ && $0 != v { exit }
+          ' readme.txt
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        with:
+          commit-message: "chore: generate changelog for ${{ inputs.version }}"
+          title: "Generate changelog for ${{ inputs.version }}"
+          body: |
+            Automated changelog draft for **${{ inputs.version }}**.
+
+            Generated from merged PRs since the previous release tag, grouped by `changelog:` label.
+
+            Please review the entries (wording, ordering, anything caught by the wrong label) before merging. Once merged into `develop`, the `Release` workflow can be run for this version.
+          branch: "changelog/${{ inputs.version }}"
+          base: develop
+          delete-branch: true
+          labels: "changelog: non-user-facing"

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -207,7 +207,7 @@ jobs:
               ENTRIES="* ${TITLE}"
             fi
             # Append a markdown PR link to each bullet for QA traceability.
-            ENTRIES=$(echo "$ENTRIES" | sed "s|\$| [#${PR_NUM}](${PR_BASE_URL}/${PR_NUM})|")
+            ENTRIES=$(printf '%s\n' "$ENTRIES" | awk -v suffix=" [#${PR_NUM}](${PR_BASE_URL}/${PR_NUM})" 'NF { print $0 suffix }')
             ENTRIES="$ENTRIES"$'\n'
             case "$LABEL" in
               enhancement)       ENH+="$ENTRIES" ;;

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -11,8 +11,11 @@ name: Release RC
 # preserving the readme.txt `Stable tag:` (so the wordpress.org listing keeps
 # pointing at the last stable release), rebuilds i18n, tags x.y-RCn on the
 # release branch, and creates a GitHub *pre-release* with the artifact zip
-# attached. Does NOT deploy to wordpress.org SVN. Finally merges the release
-# branch back into develop so the version bump and i18n changes land there too.
+# attached. Optionally deploys the build to the wordpress.org SVN trunk
+# (opt-in via `deploy-to-svn-trunk`) so translators can pick up new strings;
+# the Stable tag is preserved at the last stable release so users do NOT see
+# the RC. Finally merges the release branch back into develop so the version
+# bump and i18n changes land there too.
 ##############################################################################
 
 on:
@@ -24,6 +27,11 @@ on:
         type: string
       skip-changelog-regen:
         description: 'Skip the automatic changelog regeneration step (preserves any hand-edits on the release branch).'
+        required: false
+        default: false
+        type: boolean
+      deploy-to-svn-trunk:
+        description: 'Push the build to wordpress.org SVN trunk so translators can pick up new strings. Stable tag stays on the last stable release.'
         required: false
         default: false
         type: boolean
@@ -178,6 +186,17 @@ jobs:
 
       - name: "Grunt: build artifact"
         run: grunt artifact
+
+      - name: Deploy RC to wordpress.org SVN trunk
+        if: ${{ inputs.deploy-to-svn-trunk == true }}
+        uses: 10up/action-wordpress-plugin-deploy@stable
+        env:
+          SVN_USERNAME: ${{ secrets.WPORG_SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.WPORG_SVN_PASSWORD }}
+          SLUG: yoast-test-helper
+          VERSION: ${{ env.RC_VERSION }}
+          BUILD_DIR: ./artifact
+          ASSETS_DIR: svn-assets
 
       - name: Rename artifact zip
         id: zip

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -189,14 +189,33 @@ jobs:
 
       - name: Deploy RC to wordpress.org SVN trunk
         if: ${{ inputs.deploy-to-svn-trunk == true }}
-        uses: 10up/action-wordpress-plugin-deploy@stable
         env:
           SVN_USERNAME: ${{ secrets.WPORG_SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.WPORG_SVN_PASSWORD }}
-          SLUG: yoast-test-helper
-          VERSION: ${{ env.RC_VERSION }}
-          BUILD_DIR: ./artifact
-          ASSETS_DIR: svn-assets
+          SVN_URL: https://plugins.svn.wordpress.org/yoast-test-helper
+        run: |
+          set -euo pipefail
+          sudo apt-get install -y subversion >/dev/null
+
+          SVN_DIR="${RUNNER_TEMP}/svn"
+          svn checkout --depth=empty --non-interactive --no-auth-cache \
+            --username "$SVN_USERNAME" --password "$SVN_PASSWORD" \
+            "$SVN_URL" "$SVN_DIR"
+          svn update --set-depth=infinity --non-interactive --no-auth-cache \
+            --username "$SVN_USERNAME" --password "$SVN_PASSWORD" \
+            "$SVN_DIR/trunk" "$SVN_DIR/assets"
+
+          rsync -a --delete --exclude=.svn ./artifact/   "$SVN_DIR/trunk/"
+          rsync -a --delete --exclude=.svn ./svn-assets/ "$SVN_DIR/assets/"
+
+          pushd "$SVN_DIR" >/dev/null
+            # Stage newly-added files and removed files for SVN.
+            svn status trunk assets | awk '$1=="?" { sub(/^\?[[:space:]]+/, ""); print }' | xargs -r -d '\n' svn add --parents --force
+            svn status trunk assets | awk '$1=="!" { sub(/^\![[:space:]]+/, ""); print }' | xargs -r -d '\n' svn rm
+            svn commit --non-interactive --no-auth-cache \
+              --username "$SVN_USERNAME" --password "$SVN_PASSWORD" \
+              -m "RC ${RC_VERSION}: update trunk for translation strings"
+          popd >/dev/null
 
       - name: Rename artifact zip
         id: zip

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -49,6 +49,7 @@ jobs:
 
     permissions:
       contents: write
+      pull-requests: read
 
     env:
       RELEASE_BRANCH: "release/${{ inputs.version }}"
@@ -340,8 +341,14 @@ jobs:
       - name: Merge release branch back into develop
         run: |
           git fetch origin develop
-          git checkout develop
-          git merge --no-ff "origin/${RELEASE_BRANCH}" -m "Merge ${RELEASE_BRANCH} (${RC_VERSION}) back into develop"
+          # Reset the local develop to origin so we merge into the current upstream tip,
+          # not whatever the workflow checked out at the start of the run.
+          git checkout -B develop origin/develop
+          if ! git merge --no-ff --no-edit "origin/${RELEASE_BRANCH}" -m "Merge ${RELEASE_BRANCH} (${RC_VERSION}) back into develop"; then
+            git merge --abort || true
+            echo "::error::Merge of ${RELEASE_BRANCH} into develop failed. Resolve conflicts and re-run."
+            exit 1
+          fi
           git push origin develop
 
       - name: Write #test announcement to job summary

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -54,6 +54,15 @@ jobs:
       RELEASE_BRANCH: "release/${{ inputs.version }}"
 
     steps:
+      - name: Validate inputs
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
+            echo "::error::Invalid version '$VERSION'. Expected formats: 1.19 or 1.19.1."
+            exit 1
+          fi
+
       - name: Checkout develop
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -80,7 +89,13 @@ jobs:
             echo "Re-using existing release branch ${RELEASE_BRANCH}."
             git checkout -B "${RELEASE_BRANCH}" "origin/${RELEASE_BRANCH}"
             # Merge any new commits from develop so subsequent RCs include them.
-            git merge --no-ff origin/develop -m "Merge develop into ${RELEASE_BRANCH}" || true
+            # If this conflicts, abort and fail loudly — the human releaser needs to resolve it
+            # on the release branch before the workflow can proceed.
+            if ! git merge --no-ff --no-edit origin/develop -m "Merge develop into ${RELEASE_BRANCH}"; then
+              git merge --abort || true
+              echo "::error::Merge of develop into ${RELEASE_BRANCH} failed. Resolve conflicts on the release branch and re-run."
+              exit 1
+            fi
           else
             echo "Creating release branch ${RELEASE_BRANCH} from develop."
             git checkout -b "${RELEASE_BRANCH}"
@@ -149,7 +164,7 @@ jobs:
           package-manager-cache: false
 
       - name: Yarn install
-        run: yarn install
+        run: yarn install --frozen-lockfile
 
       - name: "Grunt: set package version to RC"
         run: grunt set-version -new-version="${RC_VERSION}"
@@ -262,7 +277,8 @@ jobs:
             LABEL=$(echo "$PR_JSON" | jq -r '[.labels[].name] | map(select(startswith("changelog:"))) | first // empty' | sed 's/^changelog: //')
             TITLE=$(echo "$PR_JSON" | jq -r '.title // ""')
             BODY=$(echo "$PR_JSON" | jq -r '.body // ""')
-            ENTRIES=$(echo "$BODY" | sed -n '/[Cc]hangelog [Ee]ntry/,/^##/p' | grep '^\*' | grep -v '^\* *$' || true)
+            # Strip HTML comments so PR-template guidance bullets aren't captured.
+            ENTRIES=$(echo "$BODY" | awk 'BEGIN{c=0} /<!--/{c=1} !c{print} /-->/{c=0}' | sed -n '/[Cc]hangelog [Ee]ntry/,/^##/p' | grep '^\*' | grep -v '^\* *$' || true)
             if [ -z "$ENTRIES" ]; then
               ENTRIES="* ${TITLE}"
             fi

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -5,7 +5,9 @@ name: Release RC
 #
 # Triggered manually with `version`. Auto-detects the next RC iteration by
 # scanning existing `${version}-RC<n>` tags. Cuts (or re-uses) a
-# release/x.y branch from develop, bumps the package version to x.y-RCn while
+# release/x.y branch from develop, regenerates the readme.txt changelog
+# section from merged PRs since the previous release tag (unless
+# `skip-changelog-regen` is true), bumps the package version to x.y-RCn while
 # preserving the readme.txt `Stable tag:` (so the wordpress.org listing keeps
 # pointing at the last stable release), rebuilds i18n, tags x.y-RCn on the
 # release branch, and creates a GitHub *pre-release* with the artifact zip
@@ -20,6 +22,11 @@ on:
         description: 'Target version (e.g., 1.19)'
         required: true
         type: string
+      skip-changelog-regen:
+        description: 'Skip the automatic changelog regeneration step (preserves any hand-edits on the release branch).'
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.version }}
@@ -71,12 +78,34 @@ jobs:
             git checkout -b "${RELEASE_BRANCH}"
           fi
 
+      - name: Configure git
+        env:
+          ACTOR: ${{ github.actor }}
+        run: |
+          git config user.name 'GitHub Action'
+          git config user.email "$ACTOR@users.noreply.github.com"
+
+      - name: Regenerate changelog from merged PRs
+        if: ${{ inputs.skip-changelog-regen != true }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          bash .github/scripts/generate-changelog.sh
+          if git diff --quiet -- readme.txt; then
+            echo "No changelog changes."
+          else
+            git add readme.txt
+            git commit -m "Update changelog for ${VERSION}"
+            git push origin "${RELEASE_BRANCH}"
+          fi
+
       - name: Verify changelog section exists
         env:
           VERSION: ${{ inputs.version }}
         run: |
           if ! grep -qF "= ${VERSION} =" readme.txt; then
-            echo "::error::No '= ${VERSION} =' section found in readme.txt. Run the 'Generate Changelog' workflow first and merge it into develop."
+            echo "::error::No '= ${VERSION} =' section found in readme.txt. Either label the relevant PRs with a 'changelog:' label so they can be picked up, or run 'Generate Changelog' first."
             exit 1
           fi
 
@@ -131,13 +160,6 @@ jobs:
 
       - name: "Grunt: build i18n"
         run: grunt build:i18n
-
-      - name: Configure git
-        env:
-          ACTOR: ${{ github.actor }}
-        run: |
-          git config user.name 'GitHub Action'
-          git config user.email "$ACTOR@users.noreply.github.com"
 
       - name: Commit and push release branch
         run: |

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -1,0 +1,269 @@
+name: Release RC
+
+##############################################################################
+# Release-candidate workflow for yoast-test-helper.
+#
+# Triggered manually with `version` and `rc-number`. Cuts (or re-uses) a
+# release/x.y branch from develop, bumps the package version to x.y-RCn while
+# preserving the readme.txt `Stable tag:` (so the wordpress.org listing keeps
+# pointing at the last stable release), rebuilds i18n, tags x.y-RCn on the
+# release branch, and creates a GitHub *pre-release* with the artifact zip
+# attached. Does NOT deploy to wordpress.org SVN. Finally merges the release
+# branch back into develop so the version bump and i18n changes land there too.
+##############################################################################
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Target version (e.g., 1.19)'
+        required: true
+        type: string
+      rc-number:
+        description: 'RC iteration number (e.g., 1 for RC1)'
+        required: true
+        default: '1'
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  release-rc:
+    name: "RC ${{ inputs.version }}-RC${{ inputs.rc-number }}"
+    runs-on: ubuntu-latest
+
+    if: github.repository_owner == 'Yoast'
+
+    permissions:
+      contents: write
+
+    env:
+      RC_VERSION: "${{ inputs.version }}-RC${{ inputs.rc-number }}"
+      RELEASE_BRANCH: "release/${{ inputs.version }}"
+
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: develop
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Create or check out release branch
+        run: |
+          git fetch origin "${RELEASE_BRANCH}" 2>/dev/null || true
+          if git show-ref --verify --quiet "refs/remotes/origin/${RELEASE_BRANCH}"; then
+            echo "Re-using existing release branch ${RELEASE_BRANCH}."
+            git checkout -B "${RELEASE_BRANCH}" "origin/${RELEASE_BRANCH}"
+            # Merge any new commits from develop so subsequent RCs include them.
+            git merge --no-ff origin/develop -m "Merge develop into ${RELEASE_BRANCH}" || true
+          else
+            echo "Creating release branch ${RELEASE_BRANCH} from develop."
+            git checkout -b "${RELEASE_BRANCH}"
+          fi
+
+      - name: Verify changelog section exists
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if ! grep -qF "= ${VERSION} =" readme.txt; then
+            echo "::error::No '= ${VERSION} =' section found in readme.txt. Run the 'Generate Changelog' workflow first and merge it into develop."
+            exit 1
+          fi
+
+      - name: Capture the current stable tag
+        id: stable
+        run: |
+          # The Stable tag must stay pointed at the last released version while we publish RCs.
+          # Prefer the highest non-RC git tag; fall back to the value currently in readme.txt.
+          LAST_TAG=$(git tag --list | grep -E '^[0-9]+\.[0-9]+(\.[0-9]+)?$' | sort -V | tail -1 || true)
+          if [ -z "$LAST_TAG" ]; then
+            LAST_TAG=$(grep -oP '(?<=Stable tag: ).*' readme.txt | head -1 || true)
+          fi
+          if [ -z "$LAST_TAG" ]; then
+            echo "::error::Could not determine the previous stable tag."
+            exit 1
+          fi
+          echo "stable=$LAST_TAG" >> "$GITHUB_OUTPUT"
+          echo "Preserving Stable tag at: $LAST_TAG"
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
+        with:
+          php-version: 7.4
+          coverage: none
+        env:
+          fail-fast: true
+
+      - name: Set up Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '14'
+          cache: ''
+          package-manager-cache: false
+
+      - name: Yarn install
+        run: yarn install
+
+      - name: "Grunt: set package version to RC"
+        run: grunt set-version -new-version="${RC_VERSION}"
+
+      - name: "Grunt: update version references"
+        run: grunt update-version
+
+      - name: Restore Stable tag in readme.txt
+        env:
+          STABLE: ${{ steps.stable.outputs.stable }}
+        run: |
+          # update-version pushes the RC string into readme.txt's Stable tag header;
+          # revert it so the wordpress.org listing keeps serving the last stable release.
+          sed -i -E "s/^Stable tag: .*/Stable tag: ${STABLE}/" readme.txt
+          grep '^Stable tag:' readme.txt
+
+      - name: "Grunt: build i18n"
+        run: grunt build:i18n
+
+      - name: Configure git
+        env:
+          ACTOR: ${{ github.actor }}
+        run: |
+          git config user.name 'GitHub Action'
+          git config user.email "$ACTOR@users.noreply.github.com"
+
+      - name: Commit and push release branch
+        run: |
+          git add -A
+          if git diff --cached --quiet; then
+            echo "Nothing to commit."
+          else
+            git commit -m "Bump version number to ${RC_VERSION}"
+          fi
+          git push origin "${RELEASE_BRANCH}"
+
+      - name: Tag the RC
+        run: |
+          git tag -a "${RC_VERSION}" -m "${RC_VERSION}"
+          git push origin "${RC_VERSION}"
+
+      - name: "Grunt: build artifact"
+        run: grunt artifact
+
+      - name: Rename artifact zip
+        id: zip
+        run: |
+          ZIP_NAME="yoast-test-helper-${RC_VERSION}.zip"
+          mv artifact.zip "${ZIP_NAME}"
+          echo "name=${ZIP_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Build QA changelog (full, with PR links and non-user-facing entries)
+        id: qa
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          PREVIOUS_TAG=$(git tag --sort=-creatordate --merged HEAD | grep -E '^[0-9]+\.[0-9]+(\.[0-9]+)?$' | head -1 || echo "")
+          if [ -z "$PREVIOUS_TAG" ]; then
+            echo "::warning::No previous release tag found; QA changelog will be empty."
+            echo "RC ${RC_VERSION}" > qa-changelog.md
+            exit 0
+          fi
+
+          {
+            echo "## ${RC_VERSION}"
+            echo ""
+            echo "Compared to \`${PREVIOUS_TAG}\`."
+            echo ""
+          } > qa-changelog.md
+
+          ENH=""; BUG=""; OTH=""; NUF=""
+          PR_NUMBERS=$(git log --grep='Merge pull request' "$PREVIOUS_TAG..HEAD" --oneline | grep -oP '#\K[0-9]+' || true)
+          for PR_NUM in $PR_NUMBERS; do
+            PR_JSON=$(gh pr view "$PR_NUM" --json labels,body,title 2>/dev/null || echo '{"labels":[],"body":"","title":""}')
+            LABEL=$(echo "$PR_JSON" | jq -r '[.labels[].name] | map(select(startswith("changelog:"))) | first // empty' | sed 's/^changelog: //')
+            TITLE=$(echo "$PR_JSON" | jq -r '.title // ""')
+            BODY=$(echo "$PR_JSON" | jq -r '.body // ""')
+            ENTRIES=$(echo "$BODY" | sed -n '/[Cc]hangelog [Ee]ntry/,/^##/p' | grep '^\*' | grep -v '^\* *$' || true)
+            if [ -z "$ENTRIES" ]; then
+              ENTRIES="* ${TITLE}"
+            fi
+            # Append (#PR) to each bullet for QA traceability.
+            ENTRIES=$(echo "$ENTRIES" | sed "s|\$| (#${PR_NUM})|")
+            ENTRIES="$ENTRIES"$'\n'
+            case "$LABEL" in
+              enhancement)       ENH+="$ENTRIES" ;;
+              bugfix)            BUG+="$ENTRIES" ;;
+              other)             OTH+="$ENTRIES" ;;
+              non-user-facing)   NUF+="$ENTRIES" ;;
+              reverted)          ;; # Skip reverted entries entirely.
+              *)                 OTH+="$ENTRIES" ;;
+            esac
+          done
+
+          {
+            if [ -n "$ENH" ]; then
+              echo "### Enhancements"
+              echo ""
+              echo -n "$ENH" | sed '/^$/d'
+              echo ""
+            fi
+            if [ -n "$BUG" ]; then
+              echo "### Bugfixes"
+              echo ""
+              echo -n "$BUG" | sed '/^$/d'
+              echo ""
+            fi
+            if [ -n "$OTH" ]; then
+              echo "### Other"
+              echo ""
+              echo -n "$OTH" | sed '/^$/d'
+              echo ""
+            fi
+            if [ -n "$NUF" ]; then
+              echo "### Non-user-facing"
+              echo ""
+              echo -n "$NUF" | sed '/^$/d'
+              echo ""
+            fi
+          } >> qa-changelog.md
+
+          echo "QA changelog:"
+          cat qa-changelog.md
+
+      - name: Create GitHub pre-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ZIP: ${{ steps.zip.outputs.name }}
+        run: |
+          gh release create "${RC_VERSION}" \
+            --title "${RC_VERSION}" \
+            --notes-file qa-changelog.md \
+            --target "${RELEASE_BRANCH}" \
+            --prerelease \
+            "${ZIP}"
+
+      - name: Merge release branch back into develop
+        run: |
+          git fetch origin develop
+          git checkout develop
+          git merge --no-ff "origin/${RELEASE_BRANCH}" -m "Merge ${RELEASE_BRANCH} (${RC_VERSION}) back into develop"
+          git push origin develop
+
+      - name: Write #test announcement to job summary
+        env:
+          ZIP: ${{ steps.zip.outputs.name }}
+        run: |
+          RELEASE_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${RC_VERSION}"
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## Slack announcement
+
+          Copy this into **#test**:
+
+          \`\`\`
+          @plugin-testers @product-rc @supportleads
+          Yoast Test Helper ${RC_VERSION} is ready for testing.
+          Pre-release: ${RELEASE_URL}
+          Zip: ${ZIP}
+          \`\`\`
+          EOF

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -3,7 +3,8 @@ name: Release RC
 ##############################################################################
 # Release-candidate workflow for yoast-test-helper.
 #
-# Triggered manually with `version` and `rc-number`. Cuts (or re-uses) a
+# Triggered manually with `version`. Auto-detects the next RC iteration by
+# scanning existing `${version}-RC<n>` tags. Cuts (or re-uses) a
 # release/x.y branch from develop, bumps the package version to x.y-RCn while
 # preserving the readme.txt `Stable tag:` (so the wordpress.org listing keeps
 # pointing at the last stable release), rebuilds i18n, tags x.y-RCn on the
@@ -19,11 +20,6 @@ on:
         description: 'Target version (e.g., 1.19)'
         required: true
         type: string
-      rc-number:
-        description: 'RC iteration number (e.g., 1 for RC1)'
-        required: true
-        default: '1'
-        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.version }}
@@ -31,7 +27,7 @@ concurrency:
 
 jobs:
   release-rc:
-    name: "RC ${{ inputs.version }}-RC${{ inputs.rc-number }}"
+    name: "RC for ${{ inputs.version }}"
     runs-on: ubuntu-latest
 
     if: github.repository_owner == 'Yoast'
@@ -40,7 +36,6 @@ jobs:
       contents: write
 
     env:
-      RC_VERSION: "${{ inputs.version }}-RC${{ inputs.rc-number }}"
       RELEASE_BRANCH: "release/${{ inputs.version }}"
 
     steps:
@@ -50,6 +45,18 @@ jobs:
           ref: develop
           fetch-depth: 0
           persist-credentials: true
+
+      - name: Determine next RC number
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          # Find the highest existing ${VERSION}-RC<n> tag and pick the next number.
+          git fetch --tags origin
+          LAST=$(git tag --list "${VERSION}-RC*" | grep -oE '[0-9]+$' | sort -n | tail -1 || true)
+          NEXT=$(( ${LAST:-0} + 1 ))
+          RC_VERSION="${VERSION}-RC${NEXT}"
+          echo "RC_VERSION=${RC_VERSION}" >> "$GITHUB_ENV"
+          echo "Previous RC: ${LAST:-none}. Next RC: ${RC_VERSION}"
 
       - name: Create or check out release branch
         run: |

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -177,10 +177,21 @@ jobs:
             exit 0
           fi
 
+          # Pick up the planned release date from the readme.txt section; fall back to today.
+          RELEASE_DATE=$(awk -v v="= ${VERSION} =" '
+            $0 == v { flag = 1; next }
+            flag && /^Release date:/ { sub(/^Release date: */, ""); print; exit }
+          ' readme.txt)
+          if [ -z "$RELEASE_DATE" ]; then
+            RELEASE_DATE=$(date +%Y-%m-%d)
+          fi
+
+          PR_BASE_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull"
+
           {
-            echo "## ${RC_VERSION}"
+            echo "## ${VERSION}"
             echo ""
-            echo "Compared to \`${PREVIOUS_TAG}\`."
+            echo "Release date: ${RELEASE_DATE}"
             echo ""
           } > qa-changelog.md
 
@@ -195,8 +206,8 @@ jobs:
             if [ -z "$ENTRIES" ]; then
               ENTRIES="* ${TITLE}"
             fi
-            # Append (#PR) to each bullet for QA traceability.
-            ENTRIES=$(echo "$ENTRIES" | sed "s|\$| (#${PR_NUM})|")
+            # Append a markdown PR link to each bullet for QA traceability.
+            ENTRIES=$(echo "$ENTRIES" | sed "s|\$| [#${PR_NUM}](${PR_BASE_URL}/${PR_NUM})|")
             ENTRIES="$ENTRIES"$'\n'
             case "$LABEL" in
               enhancement)       ENH+="$ENTRIES" ;;
@@ -210,25 +221,25 @@ jobs:
 
           {
             if [ -n "$ENH" ]; then
-              echo "### Enhancements"
+              echo "### Enhancements:"
               echo ""
               echo -n "$ENH" | sed '/^$/d'
               echo ""
             fi
             if [ -n "$BUG" ]; then
-              echo "### Bugfixes"
+              echo "### Bugfixes:"
               echo ""
               echo -n "$BUG" | sed '/^$/d'
               echo ""
             fi
             if [ -n "$OTH" ]; then
-              echo "### Other"
+              echo "### Other:"
               echo ""
               echo -n "$OTH" | sed '/^$/d'
               echo ""
             fi
             if [ -n "$NUF" ]; then
-              echo "### Non-user-facing"
+              echo "### Non user facing:"
               echo ""
               echo -n "$NUF" | sed '/^$/d'
               echo ""

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -339,6 +339,10 @@ jobs:
             "${ZIP}"
 
       - name: Merge release branch back into develop
+        # Note: this merges the RC commits — including the `Bump version number to x.y-RCn`
+        # commit — back into develop. As a result `develop`'s package.json carries the
+        # `x.y-RCn` version until the final `Release` workflow overwrites it with `x.y`.
+        # This matches the manual release procedure and the duplicate-post convention.
         run: |
           git fetch origin develop
           # Reset the local develop to origin so we merge into the current upstream tip,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,7 +171,6 @@ jobs:
         run: grunt artifact
 
       - name: Extract release notes from readme.txt
-        id: notes
         env:
           VERSION: ${{ inputs.version }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,20 @@ jobs:
       issues: write
 
     steps:
+      - name: Validate inputs
+        env:
+          VERSION: ${{ inputs.version }}
+          NEXT_INPUT: ${{ inputs.next-version }}
+        run: |
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
+            echo "::error::Invalid version '$VERSION'. Expected formats: 1.19 or 1.19.1."
+            exit 1
+          fi
+          if [ -n "$NEXT_INPUT" ] && ! [[ "$NEXT_INPUT" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
+            echo "::error::Invalid next-version '$NEXT_INPUT'. Expected formats: 1.20 or 1.19.1."
+            exit 1
+          fi
+
       - name: Resolve next version
         id: next
         env:
@@ -99,7 +113,7 @@ jobs:
           package-manager-cache: false
 
       - name: Yarn install
-        run: yarn install
+        run: yarn install --frozen-lockfile
 
       - name: "Grunt: set package version"
         env:
@@ -136,8 +150,14 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           git fetch origin main
-          git checkout main
-          git merge --no-ff develop -m "Release ${VERSION}"
+          # Create/reset local `main` from origin/main — a fresh actions/checkout only set up
+          # the `develop` branch locally, so a plain `git checkout main` would fail.
+          git checkout -B main origin/main
+          if ! git merge --no-ff --no-edit develop -m "Release ${VERSION}"; then
+            git merge --abort || true
+            echo "::error::Merge of develop into main failed. Resolve conflicts on main and re-run."
+            exit 1
+          fi
           git push origin main
 
       - name: Tag the release
@@ -164,7 +184,7 @@ jobs:
           cat release-notes.md
 
       - name: Deploy to wordpress.org SVN
-        uses: 10up/action-wordpress-plugin-deploy@stable
+        uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # v2.3.0
         env:
           SVN_USERNAME: ${{ secrets.WPORG_SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.WPORG_SVN_PASSWORD }}
@@ -222,8 +242,12 @@ jobs:
       - name: Merge main back into develop
         run: |
           git fetch origin develop
-          git checkout develop
-          git merge --no-ff main -m "Merge main back into develop"
+          git checkout -B develop origin/develop
+          if ! git merge --no-ff --no-edit main -m "Merge main back into develop"; then
+            git merge --abort || true
+            echo "::error::Merge of main into develop failed. Resolve conflicts and re-run."
+            exit 1
+          fi
           git push origin develop
 
       - name: Write Slack announcement to job summary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,10 +73,16 @@ jobs:
           if [ -n "$NEXT_INPUT" ]; then
             NEXT="$NEXT_INPUT"
           else
-            # Default: bump the minor segment (1.19 -> 1.20).
+            # Default: for a patch release (1.19.1) bump the patch segment (-> 1.19.2);
+            # for a minor release (1.19) bump the minor segment (-> 1.20).
             MAJOR=$(echo "$VERSION" | cut -d. -f1)
             MINOR=$(echo "$VERSION" | cut -d. -f2)
-            NEXT="${MAJOR}.$((MINOR + 1))"
+            PATCH=$(echo "$VERSION" | cut -d. -f3)
+            if [ -n "$PATCH" ]; then
+              NEXT="${MAJOR}.${MINOR}.$((PATCH + 1))"
+            else
+              NEXT="${MAJOR}.$((MINOR + 1))"
+            fi
           fi
           echo "next=$NEXT" >> "$GITHUB_OUTPUT"
           echo "Resolved next version: $NEXT"
@@ -197,10 +203,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ inputs.version }}
         run: |
+          # No --target: the tag pushed in the previous step is the source of truth.
+          # Passing --target main would silently create the release at main's tip
+          # if the tag step were ever skipped or rolled back partway.
           gh release create "${VERSION}" \
             --title "${VERSION}" \
             --notes-file release-notes.md \
-            --target main \
             artifact.zip
 
       - name: Rename release asset

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,242 @@
+name: Release
+
+##############################################################################
+# End-to-end release workflow for yoast-test-helper.
+#
+# Triggered manually with a `version` input (and optional `next-version`).
+# Performs the full release pipeline:
+#   1. Verifies a changelog section for the version exists in readme.txt.
+#   2. Bumps the version (package.json, plugin header, YOAST_TEST_HELPER_VERSION, Stable tag).
+#   3. Rebuilds the POT file.
+#   4. Commits to develop, merges develop into main (--no-ff), tags, pushes.
+#      (The tag push also triggers .github/workflows/deploy.yml, which builds and
+#       pushes the artifact to Yoast-dist/yoast-test-helper.)
+#   5. Builds the artifact locally and deploys it to wordpress.org SVN via the
+#      10up action (uses WPORG_SVN_USERNAME / WPORG_SVN_PASSWORD secrets).
+#   6. Creates a GitHub release with the changelog section as notes and the zip
+#      attached.
+#   7. Closes the milestone matching the version and opens a milestone for the
+#      next version.
+#   8. Merges main back into develop.
+#   9. Emits a Slack message body in the job summary for manual posting.
+##############################################################################
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g., 1.19)'
+        required: true
+        type: string
+      next-version:
+        description: 'Version for the next milestone (e.g., 1.20). Defaults to bumping the minor of `version`.'
+        required: false
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: "Release ${{ inputs.version }}"
+    runs-on: ubuntu-latest
+
+    # Don't run on forks.
+    if: github.repository_owner == 'Yoast'
+
+    permissions:
+      contents: write
+      issues: write
+
+    steps:
+      - name: Resolve next version
+        id: next
+        env:
+          VERSION: ${{ inputs.version }}
+          NEXT_INPUT: ${{ inputs.next-version }}
+        run: |
+          if [ -n "$NEXT_INPUT" ]; then
+            NEXT="$NEXT_INPUT"
+          else
+            # Default: bump the minor segment (1.19 -> 1.20).
+            MAJOR=$(echo "$VERSION" | cut -d. -f1)
+            MINOR=$(echo "$VERSION" | cut -d. -f2)
+            NEXT="${MAJOR}.$((MINOR + 1))"
+          fi
+          echo "next=$NEXT" >> "$GITHUB_OUTPUT"
+          echo "Resolved next version: $NEXT"
+
+      - name: Checkout develop
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: develop
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Verify changelog section exists
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if ! grep -qF "= ${VERSION} =" readme.txt; then
+            echo "::error::No '= ${VERSION} =' section found in readme.txt. Run the 'Generate Changelog' workflow first."
+            exit 1
+          fi
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
+        with:
+          php-version: 7.4
+          coverage: none
+        env:
+          fail-fast: true
+
+      - name: Set up Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '14'
+          cache: ''
+          package-manager-cache: false
+
+      - name: Yarn install
+        run: yarn install
+
+      - name: "Grunt: set package version"
+        env:
+          VERSION: ${{ inputs.version }}
+        run: grunt set-version -new-version="$VERSION"
+
+      - name: "Grunt: update version references"
+        run: grunt update-version
+
+      - name: "Grunt: build i18n"
+        run: grunt build:i18n
+
+      - name: Configure git
+        env:
+          ACTOR: ${{ github.actor }}
+        run: |
+          git config user.name 'GitHub Action'
+          git config user.email "$ACTOR@users.noreply.github.com"
+
+      - name: Commit version bump to develop
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          git add -A
+          if git diff --cached --quiet; then
+            echo "Nothing to commit."
+          else
+            git commit -m "Bump version number to ${VERSION}"
+          fi
+          git push origin develop
+
+      - name: Merge develop into main
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          git fetch origin main
+          git checkout main
+          git merge --no-ff develop -m "Release ${VERSION}"
+          git push origin main
+
+      - name: Tag the release
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          git tag -a "${VERSION}" -m "${VERSION}"
+          git push origin "${VERSION}"
+
+      - name: "Grunt: build artifact"
+        run: grunt artifact
+
+      - name: Extract release notes from readme.txt
+        id: notes
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          awk -v v="= ${VERSION} =" '
+            $0 == v { flag = 1; next }
+            flag && /^= [0-9]/ { exit }
+            flag { print }
+          ' readme.txt > release-notes.md
+          echo "Generated release-notes.md:"
+          cat release-notes.md
+
+      - name: Deploy to wordpress.org SVN
+        uses: 10up/action-wordpress-plugin-deploy@stable
+        env:
+          SVN_USERNAME: ${{ secrets.WPORG_SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.WPORG_SVN_PASSWORD }}
+          SLUG: yoast-test-helper
+          VERSION: ${{ inputs.version }}
+          BUILD_DIR: ./artifact
+          ASSETS_DIR: svn-assets
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          gh release create "${VERSION}" \
+            --title "${VERSION}" \
+            --notes-file release-notes.md \
+            --target main \
+            artifact.zip
+
+      - name: Rename release asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          # The zip is uploaded as artifact.zip; rename it on the release to yoast-test-helper.zip.
+          ASSET_ID=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${VERSION}" --jq '.assets[] | select(.name=="artifact.zip") | .id')
+          if [ -n "$ASSET_ID" ]; then
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/releases/assets/${ASSET_ID}" -f name=yoast-test-helper.zip
+          fi
+
+      - name: Close milestone and open the next one
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+          NEXT_VERSION: ${{ steps.next.outputs.next }}
+        run: |
+          MILESTONE_NUMBER=$(gh api "repos/${GITHUB_REPOSITORY}/milestones?state=open&per_page=100" \
+            --jq ".[] | select(.title==\"${VERSION}\") | .number" | head -1)
+          if [ -n "$MILESTONE_NUMBER" ]; then
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/milestones/${MILESTONE_NUMBER}" -f state=closed
+            echo "Closed milestone ${VERSION} (#${MILESTONE_NUMBER})"
+          else
+            echo "::warning::No open milestone titled '${VERSION}' found; skipping close."
+          fi
+
+          EXISTING_NEXT=$(gh api "repos/${GITHUB_REPOSITORY}/milestones?state=open&per_page=100" \
+            --jq ".[] | select(.title==\"${NEXT_VERSION}\") | .number" | head -1)
+          if [ -z "$EXISTING_NEXT" ]; then
+            gh api -X POST "repos/${GITHUB_REPOSITORY}/milestones" -f title="${NEXT_VERSION}" >/dev/null
+            echo "Opened milestone ${NEXT_VERSION}"
+          else
+            echo "Milestone ${NEXT_VERSION} already exists; skipping create."
+          fi
+
+      - name: Merge main back into develop
+        run: |
+          git fetch origin develop
+          git checkout develop
+          git merge --no-ff main -m "Merge main back into develop"
+          git push origin develop
+
+      - name: Write Slack announcement to job summary
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## Slack announcement
+
+          Copy this into **#yoast_support** and **#dev-rc-releases**:
+
+          \`\`\`
+          We've just released Yoast Test Helper ${VERSION}.
+          Changelog: https://wordpress.org/plugins/yoast-test-helper/#developers
+          \`\`\`
+          EOF


### PR DESCRIPTION
## Changelog Entry

This PR can be summarized in the following changelog entry:

* Adds GitHub Actions workflows to automate the plugin's release pipeline (changelog generation, full release with wordpress.org SVN deploy, and RC pre-release).

## Relevant technical choices:

* **`generate-changelog.yml`** — manual `workflow_dispatch` that runs `.github/scripts/generate-changelog.sh`. The script walks PRs merged since the previous release tag, groups them by `changelog:` label, inserts a new `= x.y =` section into `readme.txt`, and opens a PR against `develop` for review. Adapted from `duplicate-post`'s `generate-changelog.sh`; the readme.txt insertion replaces duplicate-post's separate `changelog.md` step.
* **`release.yml`** — manual `workflow_dispatch` for the full release. Bumps the version (`grunt set-version` + `update-version`, which already covers `package.json`, the plugin header, the `YOAST_TEST_HELPER_VERSION` constant, and `readme.txt`'s `Stable tag`), rebuilds i18n, commits to `develop`, merges into `main` with `--no-ff`, tags, builds the artifact, deploys to wordpress.org SVN via `10up/action-wordpress-plugin-deploy` (pinned to v2.3.0 SHA), creates the GitHub release with the zip attached, closes the milestone for the released version and opens the next (patch-aware: `1.19.1` → `1.19.2`, `1.19` → `1.20`), merges `main` back into `develop`, and emits a Slack announcement body in the job summary.
* **`release-rc.yml`** — manual `workflow_dispatch` for RC pre-releases. Takes only `version` as input and auto-detects the next RC number by scanning existing `x.y-RC<n>` tags. Cuts (or re-uses) `release/x.y`, **regenerates the readme.txt changelog section in-workflow** (no separate "Generate Changelog" run needed; opt out via `skip-changelog-regen`), bumps the package version to `x.y-RCn` while reverting `readme.txt`'s `Stable tag:` to the last released non-RC tag (so the wordpress.org listing keeps serving the previous stable), tags `x.y-RCn` on the release branch, generates a QA changelog inline (with markdown PR links and a `Non user facing:` section, matching the 1.19 manual pre-release format), creates a GitHub pre-release, and merges the release branch back into `develop`.
  * **Opt-in SVN trunk push** via `deploy-to-svn-trunk` (default false). When enabled in the same workflow run, the workflow runs an inline `svn` script that pushes `artifact/` to wordpress.org SVN `trunk/` and `svn-assets/` to `assets/` — without creating an SVN tag — so translators can pick up the new strings while the Stable tag still points at the previous stable release.
* **`deploy.yml`** — narrowed the tag trigger to exclude `*-RC*` / `*-rc*` so RC tags do not push the artifact to `Yoast-dist@main` and clobber the production listing.
* **PR template** — renamed `## Summary` to `## Changelog Entry` (stable anchor for the changelog generator) and added guidance on the four `changelog:` labels (inside an HTML comment so the generator does not pick up the example bullets).

### Secrets / config still needed before the first live run

* `WPORG_SVN_USERNAME` and `WPORG_SVN_PASSWORD` repo (or org) secrets — used by both the full-release SVN deploy and the opt-in RC trunk push.
* Verify branch-protection on `develop` and `main` allows the workflow to push directly (default `GITHUB_TOKEN`, or a bot PAT if protection blocks it).
* The four `changelog: …` labels already exist on the repo (verified).

## Milestone

* [ ] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged

The full `Release` workflow can only be exercised by doing the real 1.19 release (the plugin slug is hardcoded; there is no test-mode equivalent). The RC path is fully testable now — that's the intended acceptance test:

* Merge this PR into `release/1.19`.
* Run the **Release RC** workflow from the Actions tab once, selecting `release/1.19` as the branch and setting `version=1.19` and `deploy-to-svn-trunk=true` (leave `skip-changelog-regen` unchecked). The single run should:
  * auto-detect `1.19-RC2` as the next iteration (since `1.19-RC1` already exists);
  * commit `Update changelog for 1.19` on `release/1.19`, with the `= 1.19 =` section in `readme.txt` regenerated from labeled PRs (existing release date preserved);
  * commit `Bump version number to 1.19-RC2`; `package.json`, `yoast-test-helper.php` header, and the `YOAST_TEST_HELPER_VERSION` constant all read `1.19-RC2`; **`Stable tag:` in `readme.txt` is still `1.18`**;
  * push tag `1.19-RC2` on `release/1.19`;
  * push `artifact/` to wordpress.org SVN `trunk/` and `svn-assets/` to `assets/`, **without** creating any new `tags/1.19-RC*/` folder in SVN; the public listing at https://wordpress.org/plugins/yoast-test-helper/ continues to show `1.18`;
  * create a GitHub pre-release titled `1.19-RC2` with `yoast-test-helper-1.19-RC2.zip` attached and the QA changelog (markdown PR links + `Non user facing:` section) in the body;
  * merge `release/1.19` back into `develop`.
* (Optional, sanity check) Run **Generate Changelog** standalone with `version=1.19` from `develop` to confirm it still works as a separate review-and-merge step for cases where the changelog needs to be polished before kicking off an RC.

The `Release` workflow itself will be acceptance-tested by the actual 1.19 release; this PR's risk surface is bounded by the RC path above.

### Test instructions for QA when the code is in the RC

* [ ] QA should use the same steps as above.

Fixes #