### PR TITLE
Revert "Add ability to toggle Site Kit dashboard feature" (#242)

### DIFF
--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -84,7 +84,6 @@ class Yoast_SEO implements WordPress_Plugin {
 			'reset_premium_workouts'             => \esc_html__( 'Premium workouts progress', 'yoast-test-helper' ),
 			'reset_options'                      => \esc_html__( 'Options', 'yoast-test-helper' ),
 			'reset_cornerstone_flags'            => \esc_html__( 'Cornerstone flags', 'yoast-test-helper' ),
-			'toggle_site_kit_feature'            => \esc_html__( 'Toggle Site Kit feature flag', 'yoast-test-helper' ),
 		];
 	}
 
@@ -133,9 +132,6 @@ class Yoast_SEO implements WordPress_Plugin {
 			case 'reset_cornerstone_flags':
 				$this->reset_cornerstone_flags();
 				return true;
-			case 'toggle_site_kit_feature':
-				$this->toggle_site_kit_feature();
-				return true;
 		}
 
 		return false;
@@ -164,15 +160,6 @@ class Yoast_SEO implements WordPress_Plugin {
 		\delete_transient( 'wpseo_unindexed_term_link_count' );
 
 		$this->reset_indexing_notification( 'indexables-reset-by-test-helper' );
-	}
-
-	/**
-	 * Toggles the Site Kit feature flag.
-	 *
-	 * @return void
-	 */
-	private function toggle_site_kit_feature() {
-		WPSEO_Options::set( 'google_site_kit_feature_enabled', ! WPSEO_Options::get( 'google_site_kit_feature_enabled' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Reverts #242 ("Add ability to toggle Site Kit dashboard feature").

## Relevant technical choices:

* Reverts merge commit e43cd54 on the `release/1.19` branch, removing the `toggle_site_kit_feature` action and the associated `WPSEO_Options` toggle for `google_site_kit_feature_enabled`.

## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate the Yoast test helper plugin from this branch alongside Yoast SEO.
* Open the Yoast test helper admin page and confirm that the "Toggle Site Kit feature flag" button is no longer listed under the Yoast SEO section.
* Confirm the rest of the Yoast SEO reset/toggle buttons still work as before.

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

Fixes #