### PR TITLE
Fix RC workflow: pot-dirty merge, RC delta notes, PR-link line break

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-## Changelog Entry
+## Summary
 
 <!--
 Apply exactly one `changelog:` label to this PR:

--- a/.github/scripts/generate-changelog.sh
+++ b/.github/scripts/generate-changelog.sh
@@ -105,10 +105,13 @@ for PR_NUM in $PR_NUMBERS; do
 
 	# Strip HTML comments first so the PR template's instructional `* changelog: …` bullets
 	# (which live inside <!-- ... -->) are not picked up as changelog entries.
-	# Anchor the range on the `## Changelog Entry` *heading* (require `^##` at the start),
-	# not any bullet that happens to mention "Changelog Entry" later in the body.
+	# Anchor the range on the template intro line `This PR can be summarized in the following
+	# changelog entry:` rather than the `## …` heading. The intro phrasing is identical across
+	# the older `## Summary` template and the newer `## Changelog Entry` one, and it lives
+	# below any HTML-comment block, so we get correct ranges for both without false positives
+	# from bullets that happen to quote the heading text.
 	ENTRIES=$(echo "$BODY" | awk 'BEGIN{c=0} /<!--/{c=1} !c{print} /-->/{c=0}' \
-		| sed -n '/^## *[Cc]hangelog [Ee]ntry/,/^##/p' | grep '^\*' | grep -v '^\* *$' || true)
+		| sed -n '/[Ss]ummarized in the following [Cc]hangelog [Ee]ntry/,/^##/p' | grep '^\*' | grep -v '^\* *$' || true)
 
 	if [ -z "$ENTRIES" ]; then
 		echo "  No changelog entry found"

--- a/.github/scripts/generate-changelog.sh
+++ b/.github/scripts/generate-changelog.sh
@@ -99,13 +99,16 @@ for PR_NUM in $PR_NUMBERS; do
 		continue
 	fi
 
-	BODY=$(echo "$PR_JSON" | jq -r '.body // ""')
+	# Strip CRs (GitHub returns PR bodies with \r\n line endings; the trailing \r leaks into
+	# captured bullets and breaks the markdown rendering of any suffix we append).
+	BODY=$(echo "$PR_JSON" | jq -r '.body // ""' | tr -d '\r')
 
 	# Strip HTML comments first so the PR template's instructional `* changelog: …` bullets
 	# (which live inside <!-- ... -->) are not picked up as changelog entries.
-	# Capture bullet lines between the "Changelog Entry" anchor and the next markdown heading.
+	# Anchor the range on the `## Changelog Entry` *heading* (require `^##` at the start),
+	# not any bullet that happens to mention "Changelog Entry" later in the body.
 	ENTRIES=$(echo "$BODY" | awk 'BEGIN{c=0} /<!--/{c=1} !c{print} /-->/{c=0}' \
-		| sed -n '/[Cc]hangelog [Ee]ntry/,/^##/p' | grep '^\*' | grep -v '^\* *$' || true)
+		| sed -n '/^## *[Cc]hangelog [Ee]ntry/,/^##/p' | grep '^\*' | grep -v '^\* *$' || true)
 
 	if [ -z "$ENTRIES" ]; then
 		echo "  No changelog entry found"

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -203,6 +203,13 @@ jobs:
       - name: "Grunt: build artifact"
         run: grunt artifact
 
+      - name: Reset working tree after artifact
+        # `grunt artifact` re-runs `build:i18n`, which regenerates languages/*.pot with a fresh
+        # POT-Creation-Date timestamp. That leaves the working tree dirty and causes the later
+        # `git checkout -B develop origin/develop` to refuse to overwrite the tracked file.
+        # Throw away the in-tree changes; the artifact we just built is intact under ./artifact.
+        run: git reset --hard HEAD
+
       - name: Deploy RC to wordpress.org SVN trunk
         if: ${{ inputs.deploy-to-svn-trunk == true }}
         env:
@@ -246,12 +253,23 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ inputs.version }}
         run: |
-          PREVIOUS_TAG=$(git tag --sort=-creatordate --merged HEAD | grep -E '^[0-9]+\.[0-9]+(\.[0-9]+)?$' | head -1 || echo "")
+          # Resolve the comparison tag for the QA notes:
+          #   * RC2+ -> the immediately previous RC of the same version (RC2 vs RC1, RC3 vs RC2),
+          #     so QA only sees what's new in this RC.
+          #   * RC1  -> the most recent non-RC release tag (e.g. 1.18), so QA sees the full diff
+          #     from the last shipped version.
+          RC_NUM=$(echo "$RC_VERSION" | grep -oP '(?<=-RC)[0-9]+$')
+          if [ "$RC_NUM" -gt 1 ]; then
+            PREVIOUS_TAG="${VERSION}-RC$((RC_NUM - 1))"
+          else
+            PREVIOUS_TAG=$(git tag --sort=-creatordate --merged HEAD | grep -E '^[0-9]+\.[0-9]+(\.[0-9]+)?$' | head -1 || echo "")
+          fi
           if [ -z "$PREVIOUS_TAG" ]; then
             echo "::warning::No previous release tag found; QA changelog will be empty."
             echo "RC ${RC_VERSION}" > qa-changelog.md
             exit 0
           fi
+          echo "QA changelog comparison tag: ${PREVIOUS_TAG}"
 
           # Pick up the planned release date from the readme.txt section; fall back to today.
           RELEASE_DATE=$(awk -v v="= ${VERSION} =" '
@@ -268,6 +286,9 @@ jobs:
             echo "## ${VERSION}"
             echo ""
             echo "Release date: ${RELEASE_DATE}"
+            if [ "$RC_NUM" -gt 1 ]; then
+              echo "Changes compared to ${PREVIOUS_TAG}:"
+            fi
             echo ""
           } > qa-changelog.md
 
@@ -277,9 +298,14 @@ jobs:
             PR_JSON=$(gh pr view "$PR_NUM" --json labels,body,title 2>/dev/null || echo '{"labels":[],"body":"","title":""}')
             LABEL=$(echo "$PR_JSON" | jq -r '[.labels[].name] | map(select(startswith("changelog:"))) | first // empty' | sed 's/^changelog: //')
             TITLE=$(echo "$PR_JSON" | jq -r '.title // ""')
-            BODY=$(echo "$PR_JSON" | jq -r '.body // ""')
+            # Strip CRs (GitHub returns PR bodies with \r\n line endings; the trailing \r leaks
+            # into captured bullets and breaks markdown rendering of any suffix we append).
+            BODY=$(echo "$PR_JSON" | jq -r '.body // ""' | tr -d '\r')
             # Strip HTML comments so PR-template guidance bullets aren't captured.
-            ENTRIES=$(echo "$BODY" | awk 'BEGIN{c=0} /<!--/{c=1} !c{print} /-->/{c=0}' | sed -n '/[Cc]hangelog [Ee]ntry/,/^##/p' | grep '^\*' | grep -v '^\* *$' || true)
+            # Anchor the range on the `## Changelog Entry` *heading*, not any bullet that
+            # mentions "Changelog Entry" later in the body (e.g. PR descriptions that
+            # quote the heading inline).
+            ENTRIES=$(echo "$BODY" | awk 'BEGIN{c=0} /<!--/{c=1} !c{print} /-->/{c=0}' | sed -n '/^## *[Cc]hangelog [Ee]ntry/,/^##/p' | grep '^\*' | grep -v '^\* *$' || true)
             if [ -z "$ENTRIES" ]; then
               ENTRIES="* ${TITLE}"
             fi

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -302,10 +302,10 @@ jobs:
             # into captured bullets and breaks markdown rendering of any suffix we append).
             BODY=$(echo "$PR_JSON" | jq -r '.body // ""' | tr -d '\r')
             # Strip HTML comments so PR-template guidance bullets aren't captured.
-            # Anchor the range on the `## Changelog Entry` *heading*, not any bullet that
-            # mentions "Changelog Entry" later in the body (e.g. PR descriptions that
-            # quote the heading inline).
-            ENTRIES=$(echo "$BODY" | awk 'BEGIN{c=0} /<!--/{c=1} !c{print} /-->/{c=0}' | sed -n '/^## *[Cc]hangelog [Ee]ntry/,/^##/p' | grep '^\*' | grep -v '^\* *$' || true)
+            # Anchor the range on the template intro `This PR can be summarized in the following
+            # changelog entry:` (identical across the old `## Summary` and new `## Changelog
+            # Entry` templates) rather than the heading itself.
+            ENTRIES=$(echo "$BODY" | awk 'BEGIN{c=0} /<!--/{c=1} !c{print} /-->/{c=0}' | sed -n '/[Ss]ummarized in the following [Cc]hangelog [Ee]ntry/,/^##/p' | grep '^\*' | grep -v '^\* *$' || true)
             if [ -z "$ENTRIES" ]; then
               ENTRIES="* ${TITLE}"
             fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,6 +176,13 @@ jobs:
       - name: "Grunt: build artifact"
         run: grunt artifact
 
+      - name: Reset working tree after artifact
+        # `grunt artifact` re-runs `build:i18n`, which regenerates languages/*.pot with a fresh
+        # POT-Creation-Date timestamp. That leaves the working tree dirty and causes a later
+        # `git checkout -B <branch> origin/<branch>` to refuse to overwrite the tracked file.
+        # Throw away the in-tree changes; the artifact we just built is intact under ./artifact.
+        run: git reset --hard HEAD
+
       - name: Extract release notes from readme.txt
         env:
           VERSION: ${{ inputs.version }}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes follow-ups observed during the first live `Release RC` run for 1.19-RC2.

## Relevant technical choices:

Fixes after [run 26024024146](https://github.com/Yoast/yoast-test-helper/actions/runs/26024024146/job/76492580568) and the resulting RC2 body:

* **\`.pot\`-dirty merge-back failure.** \`grunt artifact\` re-runs \`build:i18n\`, which regenerates \`languages/yoast-test-helper.pot\` with a fresh \`POT-Creation-Date\` timestamp. That leaves the working tree dirty, and the later \`git checkout -B develop origin/develop\` step refuses to overwrite the tracked file. Adds a \`git reset --hard HEAD\` step right after \`grunt artifact\` in both workflows. The fresh \`.pot\` in the zip going to SVN is unaffected — only the in-tree spurious edit is thrown away.

* **RC2+ now diffs against the previous RC, not the previous release.** The QA changelog used \`git tag --sort=-creatordate ... | grep '^[0-9]+\\.[0-9]+(\\.[0-9]+)?$'\` as the previous-tag, which always picks the most recent *non-RC* tag (e.g. \`1.18\`). For RC2 and later this re-listed every PR since the last release, instead of just what changed in the latest iteration. Now: RC2+ uses \`\${VERSION}-RC<n-1>\` as the previous tag, RC1 still falls back to the previous non-RC release. Adds a \`Changes compared to <previous-RC>:\` line to the body for RC2+, matching the manual \`1.18-RC2..RC7\` convention.

* **PR-link line break.** GitHub returns PR bodies with \`\\r\\n\` line endings. \`grep '^\\*'\` preserved the trailing \`\\r\`, and the appended \` [#N](url)\` ended up *after* the \`\\r\`. When rendered, the CR pushed every PR link onto its own line. Fix: \`tr -d '\\r'\` on the body before parsing.

* **Anchor handles both PR templates.** The original duplicate-post pattern \`/[Cc]hangelog [Ee]ntry/\` only matched on the \"Changelog Entry\" wording, so PRs that use the legacy \`## Summary\` template (e.g. #284) would have been missed and would have fallen back to using the PR title. The anchor is now \`/[Ss]ummarized in the following [Cc]hangelog [Ee]ntry/\` — that intro line is identical across the legacy \`## Summary\` template and the newer \`## Changelog Entry\` one, and it sits below any HTML-comment block too.

* **Reverts the unnecessary PR-template heading rename.** PR #283 renamed \`## Summary\` to \`## Changelog Entry\`. With the anchor change above, that rename serves no purpose, so revert it. Keeps the new \`changelog:\` label-guidance comment that was added at the same time.

## Milestone

* [ ] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged

* Merge this into \`develop\` and then merge \`develop\` → \`release/1.19\`.
* Run **Release RC** again with \`version=1.19\`, \`deploy-to-svn-trunk=true\`. Expect RC3 to be produced and the body to read:
  * \`## 1.19\`
  * \`Release date: …\`
  * \`Changes compared to 1.19-RC2:\`
  * sections listing **only** the PRs merged since \`1.19-RC2\` (this PR and anything else that lands in the meantime)
  * each bullet with the markdown PR link on the *same line* as the changelog text
  * any PRs using the old \`## Summary\` template render with their actual changelog bullet (not a PR-title fallback).
* Verify the workflow run completes all the way through \"Merge release branch back into develop\" (no \`.pot\` dirty-tree error).

### Test instructions for QA when the code is in the RC

* [ ] QA should use the same steps as above.

Fixes #