### PR TITLE
fix(logger): create the log table before the admin viewer reads from it

### DIFF
--- a/src/logger-integration.php
+++ b/src/logger-integration.php
@@ -349,8 +349,11 @@ class Logger_Integration implements Integration {
 	 * @return string The viewer HTML.
 	 */
 	private function render_viewer() {
+		$storage = $this->get_active_storage();
+		$storage->setup();
+
 		// Read VIEWER_LIMIT + 1 so we can detect overflow and show "1000+" without counting the whole backend.
-		$entries  = $this->get_active_storage()->read( self::VIEWER_LIMIT + 1 );
+		$entries  = $storage->read( self::VIEWER_LIMIT + 1 );
 		$overflow = \count( $entries ) > self::VIEWER_LIMIT;
 		if ( $overflow ) {
 			$entries = \array_slice( $entries, 0, self::VIEWER_LIMIT );


### PR DESCRIPTION
## Changelog Entry

This PR can be summarized in the following changelog entry:

* Fixes an unreleased database error shown on the Yoast Test Helper admin page when the logger had never been enabled.

## Relevant technical choices:

* `Logger_Integration::render_viewer()` queried the storage with `read()` without first calling `setup()`. For the database backend, `setup()` is what creates the `{prefix}_yoast_test_helper_log` table via `dbDelta`. When a user installed the plugin without ever enabling the logger (so `provide_logger()` had not run), the table did not exist and visiting Tools → Yoast Test produced `Table 'wordpress.wp_yoast_test_helper_log' doesn't exist`.
* Mirrored the existing pattern used by `provide_logger()` and `handle_clear()`: fetch the active storage, call `setup()`, then operate on it. `Database_Log_Storage::setup()` short-circuits on subsequent calls via the `logger_db_version` option, so the cost on repeat renders is a single option read.

## Milestone

* [ ] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* On a fresh WordPress install with Yoast SEO active, install this version of Yoast Test Helper but do not enable the logger.
* Go to Tools → Yoast Test.
* Verify the page renders without a database error. With Query Monitor enabled, verify there is no "Table 'wp_yoast_test_helper_log' doesn't exist" entry under Database Errors.
* Verify the "Logger" section shows "0 logs captured." and the "Delete all captured logs" button is visible.
* Enable the logger (check "Enable the Yoast SEO logger.") with the Database backend selected, save, and reload the page. Verify the page still renders cleanly and the captured count updates as Yoast SEO logs entries.
* Switch the backend to "File on disk", set a valid absolute path outside `wp-content/`, save, reload, and confirm the page still renders cleanly.

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

Fixes #
