### PR TITLE
Fix RC workflow: configure git identity before the develop merge

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -71,6 +71,15 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
 
+      - name: Configure git
+        # Must run before any step that creates a git commit (including the merge commit produced
+        # by `Create or check out release branch` when the release branch already exists).
+        env:
+          ACTOR: ${{ github.actor }}
+        run: |
+          git config user.name 'GitHub Action'
+          git config user.email "$ACTOR@users.noreply.github.com"
+
       - name: Determine next RC number
         env:
           VERSION: ${{ inputs.version }}
@@ -101,13 +110,6 @@ jobs:
             echo "Creating release branch ${RELEASE_BRANCH} from develop."
             git checkout -b "${RELEASE_BRANCH}"
           fi
-
-      - name: Configure git
-        env:
-          ACTOR: ${{ github.actor }}
-        run: |
-          git config user.name 'GitHub Action'
-          git config user.email "$ACTOR@users.noreply.github.com"
 
       - name: Regenerate changelog from merged PRs
         if: ${{ inputs.skip-changelog-regen != true }}


### PR DESCRIPTION
## Summary

<!-- changelog: non-user-facing -->

This PR can be summarized in the following changelog entry:

* Fixes the RC workflow failing on RC4+ with "Please tell me who you are" when the release branch already exists and develop has new commits to merge in.

## Relevant technical choices:

The `Create or check out release branch` step does \`git merge --no-ff origin/develop\` when the release branch already exists (to pull in any fixes merged into develop between RCs). That merge needs a committer identity (\`user.name\` / \`user.email\`) to produce the merge commit — but my \`Configure git\` step ran *after* it. So the very first time the merge had something to do (RC4 of 1.19), the step died with:

\`\`\`
*** Please tell me who you are.
fatal: empty ident name (...) not allowed
\`\`\`

Fix: move \`Configure git\` to be the first step right after the \`Checkout develop\` step, so the identity is set before any commit-creating operation.

\`release.yml\` doesn't have this bug — its first commit-producing step is already after \`Configure git\`.

## Milestone

* [ ] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged

* Merge this into \`release/1.19\`.
* Re-run **Release RC** with \`version=1.19\`, \`deploy-to-svn-trunk=true\`. The \`Create or check out release branch\` step should now succeed in producing the \`Merge develop into release/1.19\` commit, and the workflow should continue all the way through to the merge-back into develop.

### Test instructions for QA when the code is in the RC

* [ ] QA should use the same steps as above.

Fixes #