### PR TITLE
Add dry-run mode to Release and Release RC workflows

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -16,6 +16,11 @@ name: Release RC
 # the Stable tag is preserved at the last stable release so users do NOT see
 # the RC. Finally merges the release branch back into develop so the version
 # bump and i18n changes land there too.
+#
+# Pass `dry-run=true` to rehearse the pipeline without any remote side effect:
+# every `git push`, the SVN deploy, the GitHub pre-release, and the merge-back
+# push are skipped. The built zip is still uploaded as a workflow artifact so
+# you can inspect it.
 ##############################################################################
 
 on:
@@ -32,6 +37,11 @@ on:
         type: boolean
       deploy-to-svn-trunk:
         description: 'Push the build to wordpress.org SVN trunk so translators can pick up new strings. Stable tag stays on the last stable release.'
+        required: false
+        default: false
+        type: boolean
+      dry-run:
+        description: 'Dry-run: do all in-tree work (changelog regen, version bump, i18n, local commit/merge/tag, artifact build) but skip every remote side-effect (no git push, no SVN, no GH pre-release). The built zip is uploaded as a workflow artifact for inspection. Overrides `deploy-to-svn-trunk`.'
         required: false
         default: false
         type: boolean
@@ -116,6 +126,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ inputs.version }}
+          DRY_RUN: ${{ inputs.dry-run }}
         run: |
           bash .github/scripts/generate-changelog.sh
           if git diff --quiet -- readme.txt; then
@@ -123,7 +134,9 @@ jobs:
           else
             git add readme.txt
             git commit -m "Update changelog for ${VERSION}"
-            git push origin "${RELEASE_BRANCH}"
+            if [ "$DRY_RUN" != "true" ]; then
+              git push origin "${RELEASE_BRANCH}"
+            fi
           fi
 
       - name: Verify changelog section exists
@@ -187,7 +200,7 @@ jobs:
       - name: "Grunt: build i18n"
         run: grunt build:i18n
 
-      - name: Commit and push release branch
+      - name: Commit version bump on release branch
         run: |
           git add -A
           if git diff --cached --quiet; then
@@ -195,12 +208,17 @@ jobs:
           else
             git commit -m "Bump version number to ${RC_VERSION}"
           fi
-          git push origin "${RELEASE_BRANCH}"
+
+      - name: Push release branch
+        if: ${{ inputs.dry-run != true }}
+        run: git push origin "${RELEASE_BRANCH}"
 
       - name: Tag the RC
-        run: |
-          git tag -a "${RC_VERSION}" -m "${RC_VERSION}"
-          git push origin "${RC_VERSION}"
+        run: git tag -a "${RC_VERSION}" -m "${RC_VERSION}"
+
+      - name: Push RC tag
+        if: ${{ inputs.dry-run != true }}
+        run: git push origin "${RC_VERSION}"
 
       - name: "Grunt: build artifact"
         run: grunt artifact
@@ -213,7 +231,7 @@ jobs:
         run: git reset --hard HEAD
 
       - name: Deploy RC to wordpress.org SVN trunk
-        if: ${{ inputs.deploy-to-svn-trunk == true }}
+        if: ${{ inputs.deploy-to-svn-trunk == true && inputs.dry-run != true }}
         env:
           SVN_USERNAME: ${{ secrets.WPORG_SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.WPORG_SVN_PASSWORD }}
@@ -248,6 +266,13 @@ jobs:
           ZIP_NAME="yoast-test-helper-${RC_VERSION}.zip"
           mv artifact.zip "${ZIP_NAME}"
           echo "name=${ZIP_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload artifact zip for inspection
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: ${{ steps.zip.outputs.name }}${{ inputs.dry-run && '-dryrun' || '' }}
+          path: ${{ steps.zip.outputs.name }}
+          retention-days: 30
 
       - name: Build QA changelog (full, with PR links and non-user-facing entries)
         id: qa
@@ -355,6 +380,7 @@ jobs:
           cat qa-changelog.md
 
       - name: Create GitHub pre-release
+        if: ${{ inputs.dry-run != true }}
         env:
           GH_TOKEN: ${{ github.token }}
           ZIP: ${{ steps.zip.outputs.name }}
@@ -371,25 +397,37 @@ jobs:
         # commit — back into develop. As a result `develop`'s package.json carries the
         # `x.y-RCn` version until the final `Release` workflow overwrites it with `x.y`.
         # This matches the manual release procedure and the duplicate-post convention.
+        env:
+          MERGE_SOURCE: ${{ inputs.dry-run == true && format('{0}', env.RELEASE_BRANCH) || format('origin/{0}', env.RELEASE_BRANCH) }}
         run: |
           git fetch origin develop
           # Reset the local develop to origin so we merge into the current upstream tip,
-          # not whatever the workflow checked out at the start of the run.
+          # not whatever the workflow checked out at the start of the run. In a real run
+          # we merge `origin/${RELEASE_BRANCH}` because the RC commits were just pushed
+          # there; in a dry-run nothing was pushed, so merge the local release branch.
           git checkout -B develop origin/develop
-          if ! git merge --no-ff --no-edit "origin/${RELEASE_BRANCH}" -m "Merge ${RELEASE_BRANCH} (${RC_VERSION}) back into develop"; then
+          if ! git merge --no-ff --no-edit "${MERGE_SOURCE}" -m "Merge ${RELEASE_BRANCH} (${RC_VERSION}) back into develop"; then
             git merge --abort || true
             echo "::error::Merge of ${RELEASE_BRANCH} into develop failed. Resolve conflicts and re-run."
             exit 1
           fi
-          git push origin develop
+
+      - name: Push develop (after merge-back)
+        if: ${{ inputs.dry-run != true }}
+        run: git push origin develop
 
       - name: Write #test announcement to job summary
         env:
           ZIP: ${{ steps.zip.outputs.name }}
+          DRY_RUN: ${{ inputs.dry-run }}
         run: |
           RELEASE_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${RC_VERSION}"
+          HEADING="## Slack announcement"
+          if [ "$DRY_RUN" = "true" ]; then
+            HEADING="## Slack announcement (preview — not actually released)"
+          fi
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-          ## Slack announcement
+          ${HEADING}
 
           Copy this into **#test**:
 
@@ -400,3 +438,31 @@ jobs:
           Zip: ${ZIP}
           \`\`\`
           EOF
+
+      - name: Dry-run summary
+        if: ${{ inputs.dry-run == true }}
+        env:
+          DEPLOY_TO_SVN_TRUNK: ${{ inputs.deploy-to-svn-trunk }}
+          ZIP: ${{ steps.zip.outputs.name }}
+        run: |
+          {
+            echo "## Dry-run summary"
+            echo ""
+            echo "Nothing was pushed. The following actions would have happened in a real run:"
+            echo ""
+            echo "* \`git push origin ${RELEASE_BRANCH}\` (with the \"Update changelog for ${{ inputs.version }}\" and \"Bump version number to ${RC_VERSION}\" commits)"
+            echo "* \`git push origin ${RC_VERSION}\` (annotated tag on \`${RELEASE_BRANCH}\`)"
+            if [ "$DEPLOY_TO_SVN_TRUNK" = "true" ]; then
+              echo "* Push to wordpress.org SVN trunk (no SVN tag)"
+            else
+              echo "* (SVN trunk push skipped — \`deploy-to-svn-trunk\` was not enabled either)"
+            fi
+            echo "* \`gh release create ${RC_VERSION} --prerelease\` with \`${ZIP}\` attached and the QA changelog below"
+            echo "* \`git push origin develop\` (after merging \`${RELEASE_BRANCH}\` back)"
+            echo ""
+            echo "The built zip is available as the \`${ZIP}-dryrun\` workflow artifact above."
+            echo ""
+            echo "### QA changelog preview"
+            echo ""
+            cat qa-changelog.md
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -272,6 +272,7 @@ jobs:
         with:
           name: ${{ steps.zip.outputs.name }}${{ inputs.dry-run && '-dryrun' || '' }}
           path: ${{ steps.zip.outputs.name }}
+          if-no-files-found: error
           retention-days: 30
 
       - name: Build QA changelog (full, with PR links and non-user-facing entries)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,11 @@ name: Release
 #      next version.
 #   8. Merges main back into develop.
 #   9. Emits a Slack message body in the job summary for manual posting.
+#
+# Pass `dry-run=true` to rehearse the pipeline without any remote side effect:
+# every `git push`, the SVN deploy, the GitHub release, and the milestone API
+# calls are skipped. The built zip is still uploaded as a workflow artifact
+# so you can inspect it.
 ##############################################################################
 
 on:
@@ -32,6 +37,11 @@ on:
         description: 'Version for the next milestone (e.g., 1.20). Defaults to bumping the minor of `version`.'
         required: false
         type: string
+      dry-run:
+        description: 'Dry-run: do all in-tree work (version bump, i18n, local commit/merge/tag, artifact build) but skip every remote side-effect (no git push, no SVN, no GH release, no milestone changes). The built zip is uploaded as a workflow artifact for inspection.'
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}
@@ -149,7 +159,10 @@ jobs:
           else
             git commit -m "Bump version number to ${VERSION}"
           fi
-          git push origin develop
+
+      - name: Push develop
+        if: ${{ inputs.dry-run != true }}
+        run: git push origin develop
 
       - name: Merge develop into main
         env:
@@ -164,14 +177,21 @@ jobs:
             echo "::error::Merge of develop into main failed. Resolve conflicts on main and re-run."
             exit 1
           fi
-          git push origin main
+
+      - name: Push main
+        if: ${{ inputs.dry-run != true }}
+        run: git push origin main
 
       - name: Tag the release
         env:
           VERSION: ${{ inputs.version }}
-        run: |
-          git tag -a "${VERSION}" -m "${VERSION}"
-          git push origin "${VERSION}"
+        run: git tag -a "${VERSION}" -m "${VERSION}"
+
+      - name: Push tag
+        if: ${{ inputs.dry-run != true }}
+        env:
+          VERSION: ${{ inputs.version }}
+        run: git push origin "${VERSION}"
 
       - name: "Grunt: build artifact"
         run: grunt artifact
@@ -195,7 +215,15 @@ jobs:
           echo "Generated release-notes.md:"
           cat release-notes.md
 
+      - name: Upload artifact zip for inspection
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: yoast-test-helper-${{ inputs.version }}${{ inputs.dry-run && '-dryrun' || '' }}
+          path: artifact.zip
+          retention-days: 30
+
       - name: Deploy to wordpress.org SVN
+        if: ${{ inputs.dry-run != true }}
         uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # v2.3.0
         env:
           SVN_USERNAME: ${{ secrets.WPORG_SVN_USERNAME }}
@@ -206,6 +234,7 @@ jobs:
           ASSETS_DIR: svn-assets
 
       - name: Create GitHub release
+        if: ${{ inputs.dry-run != true }}
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ inputs.version }}
@@ -219,6 +248,7 @@ jobs:
             artifact.zip
 
       - name: Rename release asset
+        if: ${{ inputs.dry-run != true }}
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ inputs.version }}
@@ -230,6 +260,7 @@ jobs:
           fi
 
       - name: Close milestone and open the next one
+        if: ${{ inputs.dry-run != true }}
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ inputs.version }}
@@ -262,14 +293,22 @@ jobs:
             echo "::error::Merge of main into develop failed. Resolve conflicts and re-run."
             exit 1
           fi
-          git push origin develop
+
+      - name: Push develop (after merge-back)
+        if: ${{ inputs.dry-run != true }}
+        run: git push origin develop
 
       - name: Write Slack announcement to job summary
         env:
           VERSION: ${{ inputs.version }}
+          DRY_RUN: ${{ inputs.dry-run }}
         run: |
+          HEADING="## Slack announcement"
+          if [ "$DRY_RUN" = "true" ]; then
+            HEADING="## Slack announcement (preview — not actually released)"
+          fi
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-          ## Slack announcement
+          ${HEADING}
 
           Copy this into **#yoast_support** and **#dev-rc-releases**:
 
@@ -278,3 +317,29 @@ jobs:
           Changelog: https://wordpress.org/plugins/yoast-test-helper/#developers
           \`\`\`
           EOF
+
+      - name: Dry-run summary
+        if: ${{ inputs.dry-run == true }}
+        env:
+          VERSION: ${{ inputs.version }}
+          NEXT_VERSION: ${{ steps.next.outputs.next }}
+        run: |
+          {
+            echo "## Dry-run summary"
+            echo ""
+            echo "Nothing was pushed. The following actions would have happened in a real run:"
+            echo ""
+            echo "* \`git push origin develop\` (with the \"Bump version number to ${VERSION}\" commit)"
+            echo "* \`git push origin main\` (with the \"Release ${VERSION}\" merge commit)"
+            echo "* \`git push origin ${VERSION}\` (annotated tag)"
+            echo "* Push to wordpress.org SVN: \`trunk/\`, \`assets/\`, new tag \`tags/${VERSION}/\`"
+            echo "* \`gh release create ${VERSION}\` with the artifact zip attached and the release notes below"
+            echo "* Close milestone \`${VERSION}\` and open milestone \`${NEXT_VERSION}\`"
+            echo "* \`git push origin develop\` (after merging \`main\` back)"
+            echo ""
+            echo "The built zip is available as the \`yoast-test-helper-${VERSION}-dryrun\` workflow artifact above."
+            echo ""
+            echo "### Release notes preview"
+            echo ""
+            cat release-notes.md
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,6 +220,7 @@ jobs:
         with:
           name: yoast-test-helper-${{ inputs.version }}${{ inputs.dry-run && '-dryrun' || '' }}
           path: artifact.zip
+          if-no-files-found: error
           retention-days: 30
 
       - name: Deploy to wordpress.org SVN


### PR DESCRIPTION
## Summary

<!-- changelog: non-user-facing -->

This PR can be summarized in the following changelog entry:

* Adds a \`dry-run\` input to the \`Release\` and \`Release RC\` workflows that runs the full pipeline locally on the runner and uploads the built zip as a workflow artifact, without pushing anything to the repo, SVN, or GitHub releases.

## Relevant technical choices:

When \`dry-run=true\`:

* **In-tree work still happens** — \`grunt set-version\` / \`update-version\`, \`grunt build:i18n\`, the changelog regeneration (RC only), local commits, local merges, local tags, \`grunt artifact\`. The dry-run exercises every validation and computation the real run does.
* **No remote side-effect** — \`git push\` (every branch and tag push), the wordpress.org SVN deploy, \`gh release create\`, and the milestone API calls are all skipped.
* **Artifact is uploaded** as a workflow artifact (\`yoast-test-helper-<version>[-dryrun]\`, 30-day retention) so you can download and inspect what would have shipped.
* **A \"Dry-run summary\" section** is appended to the job summary, listing exactly what would have happened and embedding the rendered release-notes / QA-changelog preview.

### Implementation notes

* The push steps were split out of the existing multi-line scripts so they can be conditionally skipped without inlining \`if [ \"\$DRY_RUN\" = ... ]\` checks everywhere. The \"Tag the release\" / \"Tag the RC\" steps similarly split into a \"create tag\" step (always runs) and a \"Push tag\" step (skipped in dry-run).
* In RC, the \"Merge release branch back into develop\" step needs to merge the *local* release branch when in dry-run (nothing was pushed to \`origin/release/x.y\`). A small \`MERGE_SOURCE\` env-var switches between \`origin/<release>\` and \`<release>\` based on the mode.
* \`deploy-to-svn-trunk\` is implicitly disabled in dry-run (both conditions must hold for the SVN step to run). The dry-run summary still mentions it as a noted skip.
* \`actions/upload-artifact\` is pinned to v7.0.0 SHA to match \`deploy.yml\`.

## Milestone

* [ ] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged

Once this is merged into \`release/1.19\`:

* Run **Release RC** with \`version=1.19\`, \`dry-run=true\`. Verify:
  * The workflow runs to completion.
  * No new tag appears on https://github.com/Yoast/yoast-test-helper/tags
  * No new pre-release appears on https://github.com/Yoast/yoast-test-helper/releases
  * No commit lands on \`release/1.19\` or \`develop\` from the run.
  * A \"yoast-test-helper-1.19-RC<n>.zip-dryrun\" workflow artifact appears on the run page and contains a versioned zip.
  * The job summary shows the \"Dry-run summary\" section with the QA changelog preview.

* Optionally: run **Release** with \`version=1.19\`, \`next-version=1.20\`, \`dry-run=true\`. Same expectations — no remote side-effects, artifact uploaded, summary shows what would have happened, including the release-notes preview.

### Test instructions for QA when the code is in the RC

* [ ] QA should use the same steps as above.

Fixes #