### PR TITLE
Fix dry-run upload: single zip with plugin folder, not zip-of-zip

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -274,7 +274,7 @@ jobs:
         # wp.org plugin zip — instead of a zip containing yoast-test-helper-x.y-RCn.zip.
         run: cp -a artifact yoast-test-helper
 
-      - name: Upload artifact zip for inspection
+      - name: Upload plugin folder as workflow artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: yoast-test-helper-${{ env.RC_VERSION }}${{ inputs.dry-run && '-dryrun' || '' }}

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -267,11 +267,18 @@ jobs:
           mv artifact.zip "${ZIP_NAME}"
           echo "name=${ZIP_NAME}" >> "$GITHUB_OUTPUT"
 
+      - name: Stage upload directory
+        # Copy the unzipped build under a `yoast-test-helper/` wrapper so the workflow
+        # artifact (which `actions/upload-artifact` always wraps in a zip of its own)
+        # downloads as a single zip containing the plugin folder — same shape as a
+        # wp.org plugin zip — instead of a zip containing yoast-test-helper-x.y-RCn.zip.
+        run: cp -a artifact yoast-test-helper
+
       - name: Upload artifact zip for inspection
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: ${{ steps.zip.outputs.name }}${{ inputs.dry-run && '-dryrun' || '' }}
-          path: ${{ steps.zip.outputs.name }}
+          name: yoast-test-helper-${{ env.RC_VERSION }}${{ inputs.dry-run && '-dryrun' || '' }}
+          path: yoast-test-helper
           if-no-files-found: error
           retention-days: 30
 
@@ -461,7 +468,7 @@ jobs:
             echo "* \`gh release create ${RC_VERSION} --prerelease\` with \`${ZIP}\` attached and the QA changelog below"
             echo "* \`git push origin develop\` (after merging \`${RELEASE_BRANCH}\` back)"
             echo ""
-            echo "The built zip is available as the \`${ZIP}-dryrun\` workflow artifact above."
+            echo "The built plugin is available as the \`yoast-test-helper-${RC_VERSION}-dryrun\` workflow artifact above (download → single zip containing the \`yoast-test-helper/\` folder)."
             echo ""
             echo "### QA changelog preview"
             echo ""

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,11 +215,18 @@ jobs:
           echo "Generated release-notes.md:"
           cat release-notes.md
 
+      - name: Stage upload directory
+        # Copy the unzipped build under a `yoast-test-helper/` wrapper so the workflow
+        # artifact (which `actions/upload-artifact` always wraps in a zip of its own)
+        # downloads as a single zip containing the plugin folder — same shape as a
+        # wp.org plugin zip — instead of a zip containing artifact.zip.
+        run: cp -a artifact yoast-test-helper
+
       - name: Upload artifact zip for inspection
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: yoast-test-helper-${{ inputs.version }}${{ inputs.dry-run && '-dryrun' || '' }}
-          path: artifact.zip
+          path: yoast-test-helper
           if-no-files-found: error
           retention-days: 30
 
@@ -338,7 +345,7 @@ jobs:
             echo "* Close milestone \`${VERSION}\` and open milestone \`${NEXT_VERSION}\`"
             echo "* \`git push origin develop\` (after merging \`main\` back)"
             echo ""
-            echo "The built zip is available as the \`yoast-test-helper-${VERSION}-dryrun\` workflow artifact above."
+            echo "The built plugin is available as the \`yoast-test-helper-${VERSION}-dryrun\` workflow artifact above (download → single zip containing the \`yoast-test-helper/\` folder)."
             echo ""
             echo "### Release notes preview"
             echo ""

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,7 +222,7 @@ jobs:
         # wp.org plugin zip — instead of a zip containing artifact.zip.
         run: cp -a artifact yoast-test-helper
 
-      - name: Upload artifact zip for inspection
+      - name: Upload plugin folder as workflow artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: yoast-test-helper-${{ inputs.version }}${{ inputs.dry-run && '-dryrun' || '' }}


### PR DESCRIPTION
## Summary

<!-- changelog: non-user-facing -->

This PR can be summarized in the following changelog entry:

* Fixes the workflow-artifact upload in \`Release\` / \`Release RC\` so the downloaded file is a single zip containing the \`yoast-test-helper/\` plugin folder, not a zip containing the plugin zip.

## Relevant technical choices:

\`actions/upload-artifact\` always wraps whatever it gets in its own zip. The previous version of the workflows passed \`path: artifact.zip\` (or the renamed \`yoast-test-helper-x.y-RCn.zip\`), so downloading the workflow artifact gave you a zip containing the plugin zip — two unzip steps before you could install.

Fix: copy the **unzipped** build (\`./artifact/\`) into a \`./yoast-test-helper/\` directory and upload that. Now the downloaded workflow artifact is a single zip containing the \`yoast-test-helper/\` folder — same shape wordpress.org expects from a plugin zip — and can be installed directly.

The original \`artifact.zip\` (release.yml) and renamed \`yoast-test-helper-x.y-RCn.zip\` (release-rc.yml) are untouched: the SVN deploy and the GitHub release attachment still use them.

## Milestone

* [ ] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged

* Merge this into \`release/1.19\`.
* Run **Release RC** with \`version=1.19\`, \`dry-run=true\`.
* Download the \`yoast-test-helper-1.19-RC<n>-dryrun\` workflow artifact from the run page.
* Verify: the downloaded file is a single zip; unzipping it produces a single \`yoast-test-helper/\` directory containing the plugin files (not a nested \`yoast-test-helper-1.19-RC<n>.zip\`).
* Optionally drop that folder into a WordPress \`wp-content/plugins/\` and confirm the plugin loads.

### Test instructions for QA when the code is in the RC

* [ ] QA should use the same steps as above.

Fixes #