### PR TITLE
Make plugin-folder staging robust against existing dirs (blueprint polish)

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -267,12 +267,20 @@ jobs:
           mv artifact.zip "${ZIP_NAME}"
           echo "name=${ZIP_NAME}" >> "$GITHUB_OUTPUT"
 
-      - name: Stage upload directory
+      - name: Stage plugin folder for upload
         # Copy the unzipped build under a `yoast-test-helper/` wrapper so the workflow
         # artifact (which `actions/upload-artifact` always wraps in a zip of its own)
         # downloads as a single zip containing the plugin folder — same shape as a
         # wp.org plugin zip — instead of a zip containing yoast-test-helper-x.y-RCn.zip.
-        run: cp -a artifact yoast-test-helper
+        #
+        # `cp -a artifact yoast-test-helper` would produce the right shape only when
+        # `yoast-test-helper/` does not already exist AND `artifact/` has no inner
+        # wrapper. Explicit `mkdir` + `cp artifact/.` removes both invariants and
+        # makes the intent unambiguous: empty wrapper dir, plus artifact contents
+        # copied into it.
+        run: |
+          mkdir yoast-test-helper
+          cp -a artifact/. yoast-test-helper/
 
       - name: Upload plugin folder as workflow artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,12 +215,20 @@ jobs:
           echo "Generated release-notes.md:"
           cat release-notes.md
 
-      - name: Stage upload directory
+      - name: Stage plugin folder for upload
         # Copy the unzipped build under a `yoast-test-helper/` wrapper so the workflow
         # artifact (which `actions/upload-artifact` always wraps in a zip of its own)
         # downloads as a single zip containing the plugin folder — same shape as a
         # wp.org plugin zip — instead of a zip containing artifact.zip.
-        run: cp -a artifact yoast-test-helper
+        #
+        # `cp -a artifact yoast-test-helper` would produce the right shape only when
+        # `yoast-test-helper/` does not already exist AND `artifact/` has no inner
+        # wrapper. Explicit `mkdir` + `cp artifact/.` removes both invariants and
+        # makes the intent unambiguous: empty wrapper dir, plus artifact contents
+        # copied into it.
+        run: |
+          mkdir yoast-test-helper
+          cp -a artifact/. yoast-test-helper/
 
       - name: Upload plugin folder as workflow artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0


### PR DESCRIPTION
## Summary

<!-- changelog: non-user-facing -->

This PR can be summarized in the following changelog entry:

* Hardens the dry-run / inspection staging step in the \`Release\` and \`Release RC\` workflows so the staged \`yoast-test-helper/\` folder has a predictable shape regardless of the runner's existing tree or the contents of \`./artifact/\`.

## Relevant technical choices:

\`cp -a artifact yoast-test-helper\` produces the intended layout (a \`yoast-test-helper/\` directory containing the plugin files) only when **two invariants** hold:

1. \`yoast-test-helper/\` does not already exist as a directory on the runner.
2. \`./artifact/\` does not contain a top-level wrapper of its own (e.g. an inner \`yoast-test-helper/\`).

Both happen to hold for yoast-test-helper today — the repo has the *file* \`yoast-test-helper.php\` (not a directory), and \`grunt artifact\`'s copy task drops plugin files at \`./artifact/\`'s root. So this isn't broken in practice.

But these workflows are about to be lifted as a blueprint for other plugin repos where neither invariant is guaranteed. Switch to:

\`\`\`bash
mkdir yoast-test-helper
cp -a artifact/. yoast-test-helper/
\`\`\`

This creates an empty wrapper directory and copies the **contents** of \`./artifact/\` into it (rather than copying the directory itself). The staged folder always has the same shape regardless of what's in \`./artifact/\` or what existed on the runner before.

Also renames the step from \"Stage upload directory\" to \"Stage plugin folder for upload\", pairing with the recently-renamed \"Upload plugin folder as workflow artifact\".

Targets \`develop\` because 1.19 is done and from here on these workflows are the template; new polish lands on develop and can be cherry-picked into other plugin repos.

## Milestone

* [ ] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged

* Once this is merged into \`develop\`, run a fresh **Release RC** \`dry-run\` for the next version (or temporarily on \`release/1.19\` after merging develop into it). Confirm:
  * The \"Stage plugin folder for upload\" step succeeds.
  * The uploaded workflow artifact (downloaded from the run page) is a single zip containing a single \`yoast-test-helper/\` directory with the plugin files at root — no double-nesting (\`yoast-test-helper/yoast-test-helper/...\`), no \`artifact/\` prefix.

### Test instructions for QA when the code is in the RC

* [ ] QA should use the same steps as above.

Fixes #