### PR TITLE
Restore RC tag triggers in deploy.yml — RC builds belong in Yoast-dist

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,14 +22,11 @@ name: Deploy
 ##############################################################################
 
 on:
-  # Trigger the workflow whenever a new tag is created.
-  # RC tags (e.g. 1.19-RC1) are excluded so they do not publish to the dist repo's main branch;
-  # RC builds are handled by the `Release RC` workflow.
+  # Trigger the workflow whenever a new tag is created — both final releases and RC tags
+  # should land in the dist repo so internal consumers can install any tagged version.
   push:
     tags:
       - '**'
-      - '!*-RC*'
-      - '!*-rc*'
   # Allow manually triggering the workflow.
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary

<!-- changelog: non-user-facing -->

This PR can be summarized in the following changelog entry:

* Fixes Deploy not publishing RC builds to Yoast-dist. Both final releases and RC tags will now trigger Deploy again, matching the established convention.

## Relevant technical choices:

PR #283 added `'!*-RC*'` / `'!*-rc*'` to `deploy.yml`'s tag-trigger list under the mistaken assumption that the dist repo's main branch should only carry final releases. The dist repo history shows that's *not* the convention — every prior RC (`1.18-RC1` through `1.18-RC7`) was already published there as a "Release x.y-RCn" commit on main, alongside the final "Release 1.18".

Result of the bad filter: Deploy silently skipped `1.19-RC2`, `1.19-RC3`, and `1.19-RC4` tag pushes. (`1.19-RC1` slipped through and *did* deploy, because it points at `cdb5d0b` — a commit predating the filter merge.)

Remove the filter. From the next RC tag push onwards, Deploy will fire and publish to `Yoast-dist@main` like it used to.

Targeting `develop` rather than `release/1.19` because there will be no further 1.19 RC; the fix is forward-looking and will be exercised by the next plugin release cycle's RC1.

### State of `Yoast-dist`

`Yoast-dist` currently has `Release 1.19-RC1`, `Release 1.19`, `Release 1.18`, … Missing: `Release 1.19-RC2/RC3/RC4`. Not backfilling — the gap is invisible to consumers going forward.

## Milestone

* [ ] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged

There's no in-flight RC for this to be validated against — coverage available now:

* Inspect the `deploy.yml` diff and confirm the `'!*-RC*'` / `'!*-rc*'` exclusions are removed from the tag-trigger list.
* `actionlint` / CI passes (workflow file still parses).

First real-world validation happens on the next plugin release cycle's RC1 — its tag push should trigger Deploy and produce a `Release <next>-RC1` commit on `Yoast-dist/yoast-test-helper@main`.

### Test instructions for QA when the code is in the RC

* [ ] QA should use the same steps as above.

Fixes #
