### PR TITLE
Conditionally load integrations that require Yoast SEO

### DIFF
--- a/src/conditionals/conditional-aware-interface.php
+++ b/src/conditionals/conditional-aware-interface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Yoast\WP\Test_Helper\Conditionals;
+
+/**
+ * An interface for classes that are aware of conditionals, which determine when they should be active.
+ */
+interface Conditional_Aware {
+
+	/**
+	 * Returns the conditionals based on which this class should be active.
+	 *
+	 * @return Conditional[]
+	 */
+	public static function get_conditionals(): array;
+}

--- a/src/conditionals/conditional-interface.php
+++ b/src/conditionals/conditional-interface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Yoast\WP\Test_Helper\Conditionals;
+
+/**
+ * Conditional interface, used to prevent integrations from loading.
+ */
+interface Conditional {
+
+	/**
+	 * Returns whether this conditional is met.
+	 *
+	 * @return bool Whether or not the conditional is met.
+	 */
+	public function is_met(): bool;
+}

--- a/src/conditionals/no-conditionals-trait.php
+++ b/src/conditionals/no-conditionals-trait.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Yoast\WP\Test_Helper\Conditionals;
+
+/**
+ * Trait No_Conditionals.
+ * This trait can be used for classes that do not have any conditionals.
+ * {@see Conditional_Aware}
+ */
+trait No_Conditionals {
+
+	/**
+	 * An empty array of conditionals, signifying that there are no conditionals for this class.
+	 *
+	 * @return Conditional[] An empty array of conditionals.
+	 */
+	public static function get_conditionals(): array {
+		return [];
+	}
+}

--- a/src/conditionals/yoastseo-conditional.php
+++ b/src/conditionals/yoastseo-conditional.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Yoast\WP\Test_Helper\Conditionals;
+
+/**
+ * Conditional to check if Yoast SEO is installed and active.
+ */
+class YoastSEO_Conditional implements Conditional {
+
+	/**
+	 * Checks if Yoast SEO is active by checking if the WPSEO_VERSION constant is defined.
+	 *
+	 * @return bool
+	 */
+	public function is_met(): bool {
+		return \defined( 'WPSEO_VERSION' );
+	}
+}

--- a/src/logger-integration.php
+++ b/src/logger-integration.php
@@ -2,13 +2,16 @@
 
 namespace Yoast\WP\Test_Helper;
 
+use Yoast\WP\Test_Helper\Conditionals\Conditional;
+use Yoast\WP\Test_Helper\Conditionals\Conditional_Aware;
+use Yoast\WP\Test_Helper\Conditionals\YoastSEO_Conditional;
 use Yoast\WP\Test_Helper\Logger\Database_Log_Storage;
 use Yoast\WP\Test_Helper\Logger\Test_Helper_Logger;
 
 /**
  * Captures logs forwarded through Yoast SEO's wpseo_logger filter to a database-backed store.
  */
-class Logger_Integration implements Integration {
+class Logger_Integration implements Integration, Conditional_Aware {
 
 	/**
 	 * Nonce action for the settings form.
@@ -311,5 +314,14 @@ class Logger_Integration implements Integration {
 		\wp_safe_redirect(
 			\self_admin_url( 'tools.php?page=' . \apply_filters( 'Yoast\WP\Test_Helper\admin_page', '' ) ),
 		);
+	}
+
+	/**
+	 * Gets the conditionals for this integration to be loaded.
+	 *
+	 * @return Conditional[]
+	 */
+	public static function get_conditionals(): array {
+		return [ new YoastSEO_Conditional() ];
 	}
 }

--- a/src/plugin.php
+++ b/src/plugin.php
@@ -27,7 +27,7 @@ class Plugin implements Integration {
 	 * Constructs the class.
 	 */
 	public function __construct() {
-		$this->load_integrations();
+		\add_action( 'plugins_loaded', [ $this, 'load_integrations' ], 10 );
 
 		\add_action( 'Yoast\WP\Test_Helper\notifications', [ $this, 'admin_page_blocks' ] );
 	}
@@ -38,11 +38,11 @@ class Plugin implements Integration {
 	 * @return void
 	 */
 	public function add_hooks() {
-		\array_map(
+		\array_walk(
+			$this->integrations,
 			static function ( Integration $integration ) {
 				$integration->add_hooks();
 			},
-			$this->integrations,
 		);
 	}
 
@@ -66,7 +66,7 @@ class Plugin implements Integration {
 	 *
 	 * @return void
 	 */
-	private function load_integrations() {
+	public function load_integrations(): void {
 		$plugins = $this->get_plugins();
 
 		$plugin_version_control = new Plugin_Version_Control(
@@ -77,30 +77,31 @@ class Plugin implements Integration {
 
 		$option = new Option();
 
-		$this->integrations[] = $plugin_version_control;
-		$this->integrations[] = new Admin_Page();
-		$this->integrations[] = new Admin_Notifications();
-		$this->integrations[] = new Upgrade_Detector();
-		$this->integrations[] = new Development_Mode( $option );
-		$this->integrations[] = new Plugin_Toggler( $option );
-		$this->integrations[] = new WordPress_Plugin_Features( $plugins );
-		$this->integrations[] = new Schema( $option );
-		$this->integrations[] = new XML_Sitemaps( $option );
-		$this->integrations[] = new Feature_Toggler( $option );
-		$this->integrations[] = new Post_Types( $option );
-		$this->integrations[] = new Taxonomies( $option );
-		$domain_dropdown      = new Domain_Dropdown( $option );
-		$this->integrations[] = $domain_dropdown;
-		$this->integrations[] = new Inline_Script( $option );
-		$this->integrations[] = new MyYoast_OAuth_Overrides( $option, $domain_dropdown );
-		$this->integrations[] = new Admin_Debug_Info( $option );
-		$this->integrations[] = new Logger_Integration( $option );
-		$this->integrations[] = new Indexing_Reason_Integration();
-		$this->integrations[] = new Query_Monitor();
-		$this->integrations[] = new Downgrader();
+		$integrations    = [];
+		$integrations[]  = $plugin_version_control;
+		$integrations[]  = new Admin_Page();
+		$integrations[]  = new Admin_Notifications();
+		$integrations[]  = new Upgrade_Detector();
+		$integrations[]  = new Development_Mode( $option );
+		$integrations[]  = new Plugin_Toggler( $option );
+		$integrations[]  = new WordPress_Plugin_Features( $plugins );
+		$integrations[]  = new Schema( $option );
+		$integrations[]  = new XML_Sitemaps( $option );
+		$integrations[]  = new Feature_Toggler( $option );
+		$integrations[]  = new Post_Types( $option );
+		$integrations[]  = new Taxonomies( $option );
+		$domain_dropdown = new Domain_Dropdown( $option );
+		$integrations[]  = $domain_dropdown;
+		$integrations[]  = new Inline_Script( $option );
+		$integrations[]  = new MyYoast_OAuth_Overrides( $option, $domain_dropdown );
+		$integrations[]  = new Admin_Debug_Info( $option );
+		$integrations[]  = new Logger_Integration( $option );
+		$integrations[]  = new Indexing_Reason_Integration();
+		$integrations[]  = new Query_Monitor();
+		$integrations[]  = new Downgrader();
 
 		$this->integrations = \array_filter(
-			$this->integrations,
+			$integrations,
 			static function ( Integration $integration ) {
 				if ( ! $integration instanceof Conditional_Aware ) {
 					return true;

--- a/src/plugin.php
+++ b/src/plugin.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\Test_Helper;
 
+use Yoast\WP\Test_Helper\Conditionals\Conditional_Aware;
 use Yoast\WP\Test_Helper\WordPress_Plugins\Local_SEO;
 use Yoast\WP\Test_Helper\WordPress_Plugins\News_SEO;
 use Yoast\WP\Test_Helper\WordPress_Plugins\Video_SEO;
@@ -97,6 +98,21 @@ class Plugin implements Integration {
 		$this->integrations[] = new Indexing_Reason_Integration();
 		$this->integrations[] = new Query_Monitor();
 		$this->integrations[] = new Downgrader();
+
+		$this->integrations = \array_filter(
+			$this->integrations,
+			static function ( Integration $integration ) {
+				if ( ! $integration instanceof Conditional_Aware ) {
+					return true;
+				}
+				foreach ( $integration::get_conditionals() as $conditional ) {
+					if ( ! $conditional->is_met() ) {
+						return false;
+					}
+				}
+				return true;
+			},
+		);
 	}
 
 	/**

--- a/src/query-monitor.php
+++ b/src/query-monitor.php
@@ -2,10 +2,14 @@
 
 namespace Yoast\WP\Test_Helper;
 
+use Yoast\WP\Test_Helper\Conditionals\Conditional;
+use Yoast\WP\Test_Helper\Conditionals\Conditional_Aware;
+use Yoast\WP\Test_Helper\Conditionals\YoastSEO_Conditional;
+
 /**
  * Class to add a Yoast SEO tab to Query Monitor.
  */
-class Query_Monitor implements Integration {
+class Query_Monitor implements Integration, Conditional_Aware {
 
 	/**
 	 * Registers our menu item and output function.
@@ -45,5 +49,14 @@ class Query_Monitor implements Integration {
 		$output['yoast-seo'] = new Query_Monitor_Output();
 
 		return $output;
+	}
+
+	/**
+	 * Gets the conditionals for this integration.
+	 *
+	 * @return Conditional[]
+	 */
+	public static function get_conditionals(): array {
+		return [ new YoastSEO_Conditional() ];
 	}
 }

--- a/yoast-test-helper.php
+++ b/yoast-test-helper.php
@@ -44,4 +44,7 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 }
 
 $yoast_test_helper = new Plugin();
-$yoast_test_helper->add_hooks();
+
+// Priority 11 ensures this runs after Plugin::load_integrations() (priority 10 on the same hook),
+// so the integrations list is built and conditionally filtered before its hooks are registered.
+add_action( 'plugins_loaded', [ $yoast_test_helper, 'add_hooks' ], 11 );


### PR DESCRIPTION

## Summary

<!--
Apply exactly one `changelog:` label to this PR:
* `changelog: enhancement` – new feature or improvement.
* `changelog: bugfix` – fixes a bug.
* `changelog: other` – anything user-facing that isn't an enhancement or bugfix.
* `changelog: non-user-facing` – internal, infra, tests, deps; excluded from the changelog.
-->

This PR can be summarized in the following changelog entry:

* Fixes a bug where the Query monitor plugin's panel would not open while Yoast SEO was not active.
* Fixes a bug where the Yoast Test Helper tools page would error while Yoast SEO was not active.

## Relevant technical choices:

* Added a `Conditional` interface (`is_met(): bool`) and a `Conditional_Aware` interface (`get_conditionals(): array`). An optional `No_Conditionals` trait provides an empty default, mostly resembling the plugin's conditional framework.
* `Plugin::load_integrations()` filters out any integration that is `Conditional_Aware` and has an unmet conditional, before any hooks are registered.
* Added `YoastSEO_Conditional`, which checks `defined( 'WPSEO_VERSION' )`.
* `Logger_Integration` and `Query_Monitor` now implement `Conditional_Aware` and require `YoastSEO_Conditional`. Neither has value without Yoast SEO, so they are fully omitted (no controls, no hooks) when it is absent.
* I chose not to make the Integration interface extend the Conditional Aware. They are two separate concepts, though they often occur in the same environment. This also means that we don't have to give all existing integrations the No_Conditional trait.

## Milestone

* [ ] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* On a site where **Yoast SEO is _not_ active** (deactivate it if needed), with Yoast Test Helper active, go to **Tools → Yoast Test** in wp-admin.
* Confirm the page loads without a fatal error. Before this change it threw `Uncaught Error: Class "YoastSEO_Vendor\Psr\Log\AbstractLogger" not found`.
* Confirm the **Logger** controls and the **Query Monitor** Yoast SEO tab are absent (these require Yoast SEO).
* Now **activate Yoast SEO** and reload **Tools → Yoast Test**. Confirm the Logger controls reappear and behave as before, and that the Yoast SEO tab is available in Query Monitor.

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

Fixes #