### PR TITLE
Composer: update to YoastCS 3.4.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		"ext-zip": "*"
 	},
 	"require-dev": {
-		"yoast/yoastcs": "^3.4.2"
+		"yoast/yoastcs": "^3.4.3"
 	},
 	"minimum-stability": "alpha",
 	"prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f8d021affa43b0fda0077cb876367bb0",
+    "content-hash": "f71122fa9721d27c31c9974a09262a97",
     "packages": [],
     "packages-dev": [
         {
@@ -892,16 +892,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.5",
+            "version": "3.13.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
                 "shasum": ""
             },
             "require": {
@@ -967,7 +967,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-04T16:30:35+00:00"
+            "time": "2026-08-06T00:17:32+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -1037,16 +1037,16 @@
         },
         {
             "name": "yoast/yoastcs",
-            "version": "3.4.2",
+            "version": "3.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/yoastcs.git",
-                "reference": "25b76061b09b1a7f437dfd789888beb1eff4e8b0"
+                "reference": "52a7f24bc4b35d6e650ac0508ac05585849950c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/yoastcs/zipball/25b76061b09b1a7f437dfd789888beb1eff4e8b0",
-                "reference": "25b76061b09b1a7f437dfd789888beb1eff4e8b0",
+                "url": "https://api.github.com/repos/Yoast/yoastcs/zipball/52a7f24bc4b35d6e650ac0508ac05585849950c5",
+                "reference": "52a7f24bc4b35d6e650ac0508ac05585849950c5",
                 "shasum": ""
             },
             "require": {
@@ -1060,7 +1060,7 @@
                 "phpcsstandards/phpcsutils": "^1.2.3",
                 "sirbrillig/phpcs-variable-analysis": "^2.13.0",
                 "slevomat/coding-standard": "^8.15.0",
-                "squizlabs/php_codesniffer": "^3.13.5",
+                "squizlabs/php_codesniffer": "^3.13.6",
                 "wp-coding-standards/wpcs": "^3.4.1"
             },
             "require-dev": {
@@ -1094,7 +1094,7 @@
                 "security": "https://github.com/Yoast/yoastcs/security/policy",
                 "source": "https://github.com/Yoast/yoastcs"
             },
-            "time": "2026-07-27T22:22:30+00:00"
+            "time": "2026-08-07T00:06:17+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION

## Summary

This PR can be summarized in the following changelog entry:

* Update dev dependencies

## Relevant technical choices:

PHP_CodeSniffer has released a security fix.

This updates enforces the use of a PHPCS version which include the fixes.

Refs:
* https://github.com/Yoast/yoastcs/releases/tag/3.4.3


## Milestone

* [x] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_