### PR TITLE
fix: also clear the quick site-information transient on reset

### DIFF
--- a/src/wordpress-plugins/yoast-seo.php
+++ b/src/wordpress-plugins/yoast-seo.php
@@ -212,6 +212,7 @@ class Yoast_SEO implements WordPress_Plugin {
 	 * @return bool True if successful, false otherwise.
 	 */
 	private function reset_site_information() {
+		\delete_transient( 'wpseo_site_information_quick' );
 		return \delete_transient( 'wpseo_site_information' );
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where resetting \"Site information\" only cleared the 24-hour transient, leaving the 60-second quick transient intact and making the reset ineffective on licence, dashboard, and plugins pages.

## Relevant technical choices:

* `reset_site_information()` now deletes both `wpseo_site_information_quick` and `wpseo_site_information`, matching exactly what `WPSEO_Addon_Manager::remove_site_information_transients()` does in production. The quick transient has a 60-second TTL and is read on the licence/dashboard/plugins pages; if it was left in place after a reset, the next page load on those screens would re-populate the slow 24h transient with stale data, making the reset a no-op.

## Milestone

* [ ] I've attached the next release's milestone to this pull request.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged

1. On a site with Yoast SEO and a valid Premium subscription, open the Yoast Test Helper and click **Reset → Site information**.
2. Navigate to the Yoast SEO licence page (`?page=wpseo_licenses`) — this page uses the quick transient.
3. Verify that the subscription status shown is fetched fresh from MyYoast (not served from a stale transient).
4. Navigate to the bulk editor page and confirm the AI generate buttons are visible (not showing "Subscription required").

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

Fixes https://github.com/Yoast/reserved-tasks/issues/1372